### PR TITLE
マイケルのハッシュ判定修正とキャラ名をGXTから取得するようにした

### DIFF
--- a/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
+++ b/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
@@ -178,11 +178,11 @@ namespace Inferno.InfernoScripts.Parupunte
             switch (hash)
             {
                 case PedHash.Trevor:
-                    return "トレバー";
-                case PedHash.Michelle:
-                    return "マイケル";
+                    return Game.GetGXTEntry("BLIP_TREV");
+                case PedHash.Michael:
+                    return Game.GetGXTEntry("BLIP_MICHAEL");
                 case PedHash.Franklin:
-                    return "フランクリン";
+                    return Game.GetGXTEntry("BLIP_FRANKLIN");
                 default:
                     return hash.ToString();
             }


### PR DESCRIPTION
GXTからキャラ名を取得することで、言語設定が日本語以外の時に(正確には日本語フォントが入ってないフォントをロードした時に)キャラ名が文字化けするのを防止出来ます(他が日本語でしか表示しないままなのであまり意味無いけど)。
