### PR TITLE
車両の体力表示追加

### DIFF
--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -156,6 +156,7 @@
     <Compile Include="InfernoScripts\Player\DisplayCauseOfDeath.cs" />
     <Compile Include="InfernoScripts\Player\EmergencyEscape.cs" />
     <Compile Include="InfernoScripts\Player\Floating.cs" />
+    <Compile Include="InfernoScripts\Player\HUDVehicleHealth.cs" />
     <Compile Include="InfernoScripts\Player\KillPlayer.cs" />
     <Compile Include="InfernoScripts\Player\PlayerHelthAlert.cs" />
     <Compile Include="InfernoScripts\Player\PlayerRagdoll.cs">

--- a/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
+++ b/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using GTA;
+using GTA.Native;
 using UniRx;
 
 namespace Inferno
@@ -16,20 +17,15 @@ namespace Inferno
     {
 
         private UIContainer _mContainer = null;
-
-        /// <summary>
-        /// 描画するゲージの種類
-        /// </summary>
-        private enum DrawStatus
-        {
-            VheicleHelth,
-            BodyHealth,
-            EngineHealth
-        };
+        private int _screenHeight;
+        private int _screenWidth;
 
         protected override void Setup()
         {
-            _mContainer = new UIContainer(new Point(0, 0), new Size(500, 20));
+            var screenResolution = NativeFunctions.GetScreenResolution();
+            _screenHeight = (int)screenResolution.Y;
+            _screenWidth = (int)screenResolution.X;
+            _mContainer = new UIContainer(new Point(0, 0), new Size(_screenWidth, _screenHeight));
 
             OnDrawingTickAsObservable
                 .Where(_ => this.GetPlayerVehicle().IsSafeExist())
@@ -57,9 +53,9 @@ namespace Inferno
             {
                 vheicleMaxHealth = vheicleHealth;
             }
-            DrawHealthBar(vheicleHealth, vheicleMaxHealth, DrawStatus.VheicleHelth);
-            DrawHealthBar(bodyHealth, 1000.0f, DrawStatus.BodyHealth);
-            DrawHealthBar(engineHealth, 1000.0f, DrawStatus.EngineHealth);
+            DrawHealthBar(vheicleHealth, vheicleMaxHealth, new Point(5, 560), Color.FromArgb(200, 200, 0, 128));
+            DrawHealthBar(bodyHealth, 1000.0f, new Point(5, 570), Color.FromArgb(200, 0, 128, 200));
+            DrawHealthBar(engineHealth, 1000.0f, new Point(5, 580), Color.FromArgb(200, 128, 200, 0));
         }
 
         /// <summary>
@@ -67,10 +63,9 @@ namespace Inferno
         /// </summary>
         /// <param name="health"></param>
         /// <param name="maxHealth"></param>
-        /// <param name="drawStatus"></param>
-        private void DrawHealthBar(float health, float maxHealth, DrawStatus drawStatus)
+        /// <param name="vhicleHealthType"></param>
+        private void DrawHealthBar(float health, float maxHealth, Point pos, Color foreGroundColor)
         {
-            var pos = default(Point);
             var width = 180;
             var height = 5;
             var margin = 2;
@@ -79,23 +74,9 @@ namespace Inferno
             var barPosition = default(Point);
             var barSize = default(Size);
             var backGroundColor = Color.FromArgb(128, 0, 0, 0);
-            var foreGroundColor = default(Color);
 
-            switch (drawStatus)
-            {
-                case DrawStatus.VheicleHelth:
-                    pos = new Point(5, 560);
-                    foreGroundColor = Color.FromArgb(200, 255, 128, 0);
-                    break;
-                case DrawStatus.BodyHealth:
-                    pos = new Point(5, 570);
-                    foreGroundColor = Color.FromArgb(200, 0, 255, 200);
-                    break;
-                case DrawStatus.EngineHealth:
-                    pos = new Point(5, 580);
-                    foreGroundColor = Color.FromArgb(200, 255, 0, 128);
-                    break;
-            }
+            var t = Function.Call<float>(Hash._GET_SCREEN_ASPECT_RATIO, true);
+            width = (int)(width + (width*(1.75f - t)));
 
             barLength = (int)(width * (health / maxHealth));
             if (barLength < 0) barLength = 0;

--- a/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
+++ b/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
@@ -28,7 +28,7 @@ namespace Inferno
             _mContainer = new UIContainer(new Point(0, 0), new Size(_screenWidth, _screenHeight));
 
             OnDrawingTickAsObservable
-                .Where(_ => this.GetPlayerVehicle().IsSafeExist())
+                .Where(_ => this.GetPlayerVehicle().IsSafeExist() && PlayerPed.IsAlive)
                 .Subscribe(_ =>
                 {
                     _mContainer.Items.Clear();

--- a/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
+++ b/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
@@ -49,10 +49,7 @@ namespace Inferno
             var engineHealth = vheicle.EngineHealth;
             var vheicleHealth = vheicle.Health;
             var vheicleMaxHealth = vheicle.MaxHealth;
-            if (vheicleHealth > vheicleMaxHealth)
-            {
-                vheicleMaxHealth = vheicleHealth;
-            }
+
             DrawHealthBar(vheicleHealth, vheicleMaxHealth, new Point(5, 560), Color.FromArgb(200, 200, 0, 128));
             DrawHealthBar(bodyHealth, 1000.0f, new Point(5, 570), Color.FromArgb(200, 0, 128, 200));
             DrawHealthBar(engineHealth, 1000.0f, new Point(5, 580), Color.FromArgb(200, 128, 200, 0));
@@ -77,6 +74,11 @@ namespace Inferno
 
             var t = Function.Call<float>(Hash._GET_SCREEN_ASPECT_RATIO, true);
             width = (int)(width + (width*(1.75f - t)));
+
+            if (health > maxHealth)
+            {
+                maxHealth = health;
+            }
 
             barLength = (int)(width * (health / maxHealth));
             if (barLength < 0) barLength = 0;

--- a/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
+++ b/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GTA;
+using UniRx;
+
+namespace Inferno
+{
+    /// <summary>
+    /// 乗り物の体力表示
+    /// </summary>
+    class HUDVehicleHealth : InfernoScript
+    {
+
+        private UIContainer _mContainer = null;
+
+        /// <summary>
+        /// 描画するゲージの種類
+        /// </summary>
+        private enum DrawStatus
+        {
+            VheicleHelth,
+            BodyHealth,
+            EngineHealth
+        };
+
+        protected override void Setup()
+        {
+            _mContainer = new UIContainer(new Point(0, 0), new Size(500, 20));
+
+            OnDrawingTickAsObservable
+                .Where(_ => this.GetPlayerVehicle().IsSafeExist())
+                .Subscribe(_ =>
+                {
+                    _mContainer.Items.Clear();
+                    GetVehicleHealth();
+                    _mContainer.Draw();
+                });
+        }
+
+        /// <summary>
+        /// 乗り物の体力を取得する
+        /// </summary>
+        private void GetVehicleHealth()
+        {
+            var vheicle = this.GetPlayerVehicle();
+            if(!vheicle.IsSafeExist()) return;
+
+            var bodyHealth = vheicle.BodyHealth;
+            var engineHealth = vheicle.EngineHealth;
+            var vheicleHealth = vheicle.Health;
+            var vheicleMaxHealth = vheicle.MaxHealth;
+            if (vheicleHealth > vheicleMaxHealth)
+            {
+                vheicleMaxHealth = vheicleHealth;
+            }
+            DrawHealthBar(vheicleHealth, vheicleMaxHealth, DrawStatus.VheicleHelth);
+            DrawHealthBar(bodyHealth, 1000.0f, DrawStatus.BodyHealth);
+            DrawHealthBar(engineHealth, 1000.0f, DrawStatus.EngineHealth);
+        }
+
+        /// <summary>
+        /// 体力ゲージを描画する
+        /// </summary>
+        /// <param name="health"></param>
+        /// <param name="maxHealth"></param>
+        /// <param name="drawStatus"></param>
+        private void DrawHealthBar(float health, float maxHealth, DrawStatus drawStatus)
+        {
+            var pos = default(Point);
+            var width = 180;
+            var height = 5;
+            var margin = 2;
+
+            var barLength = 0;
+            var barPosition = default(Point);
+            var barSize = default(Size);
+            var backGroundColor = Color.FromArgb(128, 0, 0, 0);
+            var foreGroundColor = default(Color);
+
+            switch (drawStatus)
+            {
+                case DrawStatus.VheicleHelth:
+                    pos = new Point(5, 560);
+                    foreGroundColor = Color.FromArgb(200, 255, 128, 0);
+                    break;
+                case DrawStatus.BodyHealth:
+                    pos = new Point(5, 570);
+                    foreGroundColor = Color.FromArgb(200, 0, 255, 200);
+                    break;
+                case DrawStatus.EngineHealth:
+                    pos = new Point(5, 580);
+                    foreGroundColor = Color.FromArgb(200, 255, 0, 128);
+                    break;
+            }
+
+            barLength = (int)(width * (health / maxHealth));
+            if (barLength < 0) barLength = 0;
+            barPosition = new Point(pos.X, pos.Y);
+            barSize = new Size(barLength, height);
+
+            _mContainer.Items.Add(new UIRectangle(new Point(pos.X - margin, pos.Y - margin),
+                new Size(width + margin * 2, height + margin * 2), backGroundColor));
+            _mContainer.Items.Add(new UIRectangle(barPosition, barSize, foreGroundColor));
+        }
+    }
+}


### PR DESCRIPTION
車両に乗っている際にその車両の体力を表示するようにしてみました。
赤色：エンジン（0になるとエンジンから発火か即爆発する）
緑：ボディ（0になっても何が変わったのかわからない）　
オレンジ：車両の体力（でも0になっても何も起きない）

![2016-02-24_00002](https://cloud.githubusercontent.com/assets/12034371/13257544/99b6aa9c-da92-11e5-85b5-cf043bee3490.jpg)
![2016-02-24_00001](https://cloud.githubusercontent.com/assets/12034371/13257546/9a41b57e-da92-11e5-8779-a1b0b0fd4c77.jpg)
