### PR TITLE
Weather.Unknownを天候変化の対象から除外

### DIFF
--- a/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWeather.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWeather.cs
@@ -25,6 +25,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
             weather = Enum.GetValues(typeof(Weather))
                 .Cast<Weather>()
+                .Where(x => x != Weather.Unknown)
                 .OrderBy(x => random.Next())
                 .FirstOrDefault();
 


### PR DESCRIPTION
`World.Weather` のgetter実装した時に(ScriptHookVDotNet側で未定義な値ぐらいで例外吐くのもよろしくないし)便宜的に `Weather.Unknown` 追加したせいで「わからん」を引く可能性がある状況になってたんですよ...(ちなみに `World.Weather` をセットしたところで何も変化なし)
