### PR TITLE
セーフゾーンの大きさに合わせてゲージ表示位置が変わるように

### DIFF
--- a/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
+++ b/Inferno/InfernoScripts/Player/HUDVehicleHealth.cs
@@ -57,9 +57,14 @@ namespace Inferno
                 vheiclePetrolTankHealth += 1000.0f;
             }
 
-            DrawHealthBar(vheiclePetrolTankHealth, 1000.0f, new Point(5, 560), petrolTankHealthColor);
-            DrawHealthBar(bodyHealth, 1000.0f, new Point(5, 570), Color.FromArgb(200, 0, 128, 200));
-            DrawHealthBar(engineHealth, 1000.0f, new Point(5, 580), Color.FromArgb(200, 128, 200, 0));
+            //レーダーマップとの干渉回避
+            var safeZoneSize = Function.Call<float>(Hash.GET_SAFE_ZONE_SIZE);
+            var barXPosition = 550 - (int)(545 * safeZoneSize);
+            var barYPosition = 240 + (int)(315 * safeZoneSize);
+
+            DrawHealthBar(vheiclePetrolTankHealth, 1000.0f, new Point(barXPosition, barYPosition), petrolTankHealthColor);
+            DrawHealthBar(bodyHealth, 1000.0f, new Point(barXPosition, barYPosition + 10), Color.FromArgb(200, 0, 128, 200));
+            DrawHealthBar(engineHealth, 1000.0f, new Point(barXPosition, barYPosition + 20), Color.FromArgb(200, 128, 200, 0));
         }
 
         /// <summary>


### PR DESCRIPTION
GTA5本体でのセーフゾーンの大きさ設定によってはレーダーマップと体力ゲージが重なる現象があったので、大きさに合わせて位置が変わるように修正しました。
![20160516205752_1](https://cloud.githubusercontent.com/assets/12034371/15289160/3d2f7fc4-1bab-11e6-8c72-4ab6c40a4973.jpg)
![20160516205802_1](https://cloud.githubusercontent.com/assets/12034371/15289162/3f62380e-1bab-11e6-9d3f-3c6f08b5c607.jpg)
![20160516205819_1](https://cloud.githubusercontent.com/assets/12034371/15289164/41246874-1bab-11e6-838a-d4339abe79a2.jpg)
