### PR TITLE
プレイヤーが無敵かつ徒歩時に磯野パルプンテが例外を投げていたのを修正

### DIFF
--- a/Inferno/ChaosMode/ChaosMode.cs
+++ b/Inferno/ChaosMode/ChaosMode.cs
@@ -185,7 +185,7 @@ namespace Inferno.ChaosMode
             //以下ループ
             do
             {
-                if (!ped.IsSafeExist() || !PlayerPed.IsSafeExist())
+                if (!ped.IsSafeExist() || ped.IsDead || !PlayerPed.IsSafeExist())
                 {
                     break;
                 }
@@ -207,6 +207,11 @@ namespace Inferno.ChaosMode
                 }
 
                 yield return RandomWait();
+
+                if (!ped.IsSafeExist() || ped.IsDead)
+                {
+                    break;
+                }
 
                 //攻撃する
                 PedRiot(ped, equipedWeapon);

--- a/Inferno/InfernoScripts/Parupunte/Scripts/Isono.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/Isono.cs
@@ -40,7 +40,8 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             player.CanRagdoll = true;
             player.SetToRagdoll(3000);
             player.IsCollisionProof = true;
-            if (player.IsInvincible)
+
+            if (player.IsInVehicle())
             {
                 player.CurrentVehicle.IsCollisionProof = true;
             }


### PR DESCRIPTION
`Script.Dispose`はv3で削除される予定なので`Script.Aborted`のイベントハンドラーを使うように修正お願いします。 https://github.com/crosire/scripthookvdotnet/releases/tag/v2.9
あとガルパンのパルプンテで終了後もミッションEntityのフラグ残ってるのはバグの気がするんですけどどうですかね？
