### PR TITLE
時間管理をSchedulerに統一

### DIFF
--- a/Inferno/ChaosMode/ChaosMode.cs
+++ b/Inferno/ChaosMode/ChaosMode.cs
@@ -186,7 +186,6 @@ namespace Inferno.ChaosMode
         /// <returns></returns>
         private IEnumerable<Object> ChaosPedAction(Ped ped)
         {
-            yield return RandomWait();
 
             //魚なら除外する
             var m = (uint)ped.Model.Hash;

--- a/Inferno/ChaosMode/ChaosMode.cs
+++ b/Inferno/ChaosMode/ChaosMode.cs
@@ -52,8 +52,6 @@ namespace Inferno.ChaosMode
 
         private MissionCharacterTreatmentType nextTreatType;
 
-        protected override int TickInterval => 100;
-
         private int chaosRelationShipId;
 
         protected override void Setup()
@@ -111,14 +109,16 @@ namespace Inferno.ChaosMode
             //interval設定
             Interval = chaosModeSetting.Interval;
 
+            var oneSecondTich = CreateTickAsObservable(TimeSpan.FromSeconds(1));
+
             //市民をカオス化する
-            CreateTickAsObservable(1000)
+            oneSecondTich
                 .Where(_ => IsActive && PlayerPed.IsSafeExist() && PlayerPed.IsAlive)
                 .Subscribe(_ => CitizenChaos());
 
             //プレイヤが死んだらリセット
-            CreateTickAsObservable(1000)
-                .Where(_ => PlayerPed.IsSafeExist())
+            oneSecondTich
+                 .Where(_ => PlayerPed.IsSafeExist())
                 .Select(_ => PlayerPed.IsDead)
                 .DistinctUntilChanged()
                 .Where(x => x)
@@ -128,7 +128,7 @@ namespace Inferno.ChaosMode
                     StopAllChaosCoroutine();
                 });
 
-            CreateTickAsObservable(1000)
+            oneSecondTich
                 .Where(_ => IsActive)
                 .Subscribe(_ => NativeFunctions.SetAllRandomPedsFlee(Game.Player, false));
 

--- a/Inferno/ChaosMode/ChaosMode.cs
+++ b/Inferno/ChaosMode/ChaosMode.cs
@@ -2,6 +2,7 @@
 using GTA.Native;
 using Inferno.ChaosMode.WeaponProvider;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -175,6 +176,7 @@ namespace Inferno.ChaosMode
                 StopCoroutine(id);
             }
             coroutineIds.Clear();
+
         }
 
         /// <summary>

--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -203,7 +203,9 @@
     <Compile Include="Utilities\InfernoConfigLoader.cs" />
     <Compile Include="Utilities\InfernoScheduler.cs" />
     <Compile Include="Utilities\InfernoUtilities.cs" />
+    <Compile Include="Utilities\PriorityQueue.cs" />
     <Compile Include="Utilities\RequestDataPackage.cs" />
+    <Compile Include="Utilities\ScheduledItem.cs" />
     <Compile Include="Utilities\SingleThreadSynchronizationContext.cs" />
     <Compile Include="Utilities\TCPManager.cs" />
   </ItemGroup>

--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -108,6 +108,8 @@
     <Compile Include="InfernoScripts\Event\ChasoMode\ChasoModeEvent.cs" />
     <Compile Include="InfernoScripts\Event\IEventMessage.cs" />
     <Compile Include="InfernoScripts\Event\Isono\IsonoMessage.cs" />
+    <Compile Include="InfernoScripts\InfernoCore\Coroutine\Awaitable.cs" />
+    <Compile Include="InfernoScripts\InfernoCore\Coroutine\CoroutinePool.cs" />
     <Compile Include="InfernoScripts\InfernoCore\Counter\ReduceCounter.cs" />
     <Compile Include="InfernoScripts\InfernoCore\Drawer\TimerUITextManager.cs" />
     <Compile Include="InfernoScripts\InfernoCore\IsonoManager.cs" />
@@ -175,7 +177,7 @@
     <Compile Include="InfernoScripts\Player\BondCar.cs" />
     <Compile Include="InfernoScripts\Player\DeathSoundEffect.cs" />
     <Compile Include="ExtensionMethods\ExtensionMethods.cs" />
-    <Compile Include="InfernoScripts\InfernoCore\CoroutineSystem.cs" />
+    <Compile Include="InfernoScripts\InfernoCore\Coroutine\CoroutineSystem.cs" />
     <Compile Include="InfernoScripts\InfernoCore\Debug\DebugLogger.cs" />
     <Compile Include="InfernoScripts\InfernoCore\Enums\Enums.cs" />
     <Compile Include="InfernoScripts\InfernoCore\InfernoCore.cs" />

--- a/Inferno/InfernoScripts/Citizen/CitizenCrazyDriving.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenCrazyDriving.cs
@@ -25,7 +25,7 @@ namespace Inferno
 
             OnAllOnCommandObservable.Subscribe(_ => IsActive = true);
 
-            CreateTickAsObservable(3000)
+            CreateTickAsObservable(TimeSpan.FromSeconds(3))
                 .Where(_ => IsActive)
                 .Subscribe(_ => RunAway());
         }

--- a/Inferno/InfernoScripts/Citizen/CitizenNitro.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenNitro.cs
@@ -48,7 +48,7 @@ namespace Inferno
             OnAllOnCommandObservable.Subscribe(_ => IsActive = true);
 
             //interval間隔で実行
-            CreateTickAsObservable(3000)
+            CreateTickAsObservable(TimeSpan.FromSeconds(3))
                 .Where(_ => IsActive)
                 .Subscribe(_ => CitizenNitroAction());
         }

--- a/Inferno/InfernoScripts/Citizen/CitizenRobberVehicle.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenRobberVehicle.cs
@@ -31,7 +31,7 @@ namespace Inferno
                     DrawText("CitizenRobberVehicle:" + IsActive, 3.0f);
                 });
 
-            CreateTickAsObservable(1000)
+            CreateTickAsObservable(TimeSpan.FromSeconds(1))
                 .Where(_ => IsActive)
                 .Subscribe(_ => RobberVehicle());
 

--- a/Inferno/InfernoScripts/Citizen/CitizenVehicleBomb.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenVehicleBomb.cs
@@ -37,7 +37,7 @@ namespace Inferno
 
             OnAllOnCommandObservable.Subscribe(_ => IsActive = true);
 
-            CreateTickAsObservable(5000)
+            CreateTickAsObservable(TimeSpan.FromSeconds(5))
                 .Where(_ => IsActive)
                 .Subscribe(_ => VehicleBombAction());
         }

--- a/Inferno/InfernoScripts/Citizen/SpawnParachuteCitizenArmy.cs
+++ b/Inferno/InfernoScripts/Citizen/SpawnParachuteCitizenArmy.cs
@@ -43,7 +43,7 @@ namespace Inferno
 
             OnAllOnCommandObservable.Subscribe(_ => IsActive = true);
 
-            CreateTickAsObservable(SpawnDurationSeconds * 1000)
+            CreateTickAsObservable(TimeSpan.FromSeconds(SpawnDurationSeconds))
                 .Where(_ => IsActive)
                 .Subscribe(_ => CreateParachutePed());
         }

--- a/Inferno/InfernoScripts/CitizenAttachVehicle.cs
+++ b/Inferno/InfernoScripts/CitizenAttachVehicle.cs
@@ -63,7 +63,7 @@ namespace Inferno.InfernoScripts
                 });
 
             //車から降りたら終了
-            this.OnTickAsObservable
+            this.OnThinnedTickAsObservable
                 .Select(_ => PlayerPed.IsInVehicle())
                 .DistinctUntilChanged()
                 .Where(x => !x)

--- a/Inferno/InfernoScripts/InfernoCore/Coroutine/Awaitable.cs
+++ b/Inferno/InfernoScripts/InfernoCore/Coroutine/Awaitable.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UniRx;
+
+namespace Inferno.InfernoScripts.InfernoCore.Coroutine
+{
+    public static class Awaitable
+    {
+        private static Stopwatch stopWatch = Stopwatch.StartNew();
+        private static TimeSpan Time => stopWatch.Elapsed;
+
+        /// <summary>
+        /// 指定時間待機するコルーチンを生成する
+        /// </summary>
+        public static IEnumerable ToCoroutine(TimeSpan timeSpan)
+        {
+            var dt = Time + Scheduler.Normalize(timeSpan);
+
+            while ((dt - Time).Ticks > 0)
+            {
+                yield return null;
+            }
+        }
+    }
+}

--- a/Inferno/InfernoScripts/InfernoCore/Coroutine/CoroutinePool.cs
+++ b/Inferno/InfernoScripts/InfernoCore/Coroutine/CoroutinePool.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+
+namespace Inferno.InfernoScripts.InfernoCore.Coroutine
+{
+    /// <summary>
+    /// 複数のコルーチンを順繰りに実行する
+    /// </summary>
+    class CoroutinePool
+    {
+        private readonly int _poolSize;
+        private int next = 0;
+        private readonly CoroutineSystem[] _coroutines;
+
+        /// <summary>
+        /// poolのRunを呼び出すべき間隔
+        /// 1つあたり100ms間隔になるようにする
+        /// </summary>
+        public int ExpectExecutionInterbalMillSeconds => 100 / _poolSize;
+
+        public CoroutinePool(int poolSize)
+        {
+            this._poolSize = poolSize;
+            _coroutines = new CoroutineSystem[poolSize];
+            for (var i = 0; i < _poolSize; i++)
+            {
+                _coroutines[i] = new CoroutineSystem();
+            }
+        }
+
+        /// <summary>
+        /// 次のコルーチンを実行する
+        /// 実行するとIndexが進む
+        /// </summary>
+        public void Run()
+        {
+            _coroutines[next].CoroutineLoop();
+            next = (next + 1) % _poolSize;
+        }
+
+        /// <summary>
+        /// コルーチンを登録する
+        /// 次に実行されるIndexのコルーチンに登録される
+        /// </summary>
+        public uint RegisterCoroutine(IEnumerable<object> coroutine)
+        {
+            return _coroutines[next].AddCoroutine(coroutine);
+        }
+
+        /// <summary>
+        /// コルーチンを削除する
+        /// </summary>
+        public void RemoveCoroutine(uint coroutinId)
+        {
+            foreach (var c in _coroutines)
+            {
+                //どこに登録されたかわからないので全部叩く
+                c.RemoveCoroutine(coroutinId);
+            }
+        }
+
+        public void RemoveAllCoroutine()
+        {
+            foreach (var c in _coroutines)
+            {
+                c.RemoveAllCoroutine();
+            }
+        }
+    }
+}

--- a/Inferno/InfernoScripts/InfernoCore/CoroutineSystem.cs
+++ b/Inferno/InfernoScripts/InfernoCore/CoroutineSystem.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Markup.Localizer;
 
 namespace Inferno
 {
@@ -19,12 +18,7 @@ namespace Inferno
         private uint _coroutineIdIndex = 0;
         private readonly object _lockObject = new object();
         private readonly List<uint> _stopCoroutineList = new List<uint>();
-        private readonly DebugLogger logger;
-
-        public CoroutineSystem(DebugLogger logger = null)
-        {
-            this.logger = logger;
-        }
+        List<uint> endIdList = new List<uint>();
 
         /// <summary>
         /// コルーチンの登録
@@ -83,7 +77,6 @@ namespace Inferno
         /// </summary>
         public void CoroutineLoop()
         {
-            KeyValuePair<uint, IEnumerator>[] coroutineArray;
 
             lock (_lockObject)
             {
@@ -93,15 +86,10 @@ namespace Inferno
                     _coroutines.Remove(stopId);
                 }
                 _stopCoroutineList.Clear();
-                coroutineArray = _coroutines.ToArray();
             }
 
-            var endIdList = new List<uint>();
-
-            //forの方がforeachよりちょっとだけはやい
-            for (int index = 0, max = coroutineArray.Length; index < max; index++)
+            foreach (var coroutine in _coroutines)
             {
-                var coroutine = coroutineArray[index];
                 try
                 {
                     if (!coroutine.Value.MoveNext())
@@ -111,7 +99,6 @@ namespace Inferno
                 }
                 catch (Exception e)
                 {
-                    logger?.Log(e.ToString());
                     endIdList.Add(coroutine.Key);
                 }
             }
@@ -121,6 +108,7 @@ namespace Inferno
                 {
                     _coroutines.Remove(id);
                 }
+                endIdList.Clear();
             }
         }
     }

--- a/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
+++ b/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
@@ -1,16 +1,14 @@
-﻿using GTA;
-using GTA.Math;
-using GTA.Native;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Windows.Forms;
+using GTA;
+using GTA.Math;
+using GTA.Native;
 using Inferno.InfernoScripts.Event;
-using Inferno.InfernoScripts.Event.ChasoMode;
 using Inferno.InfernoScripts.Event.Isono;
 using UniRx;
 

--- a/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
+++ b/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
@@ -53,8 +53,6 @@ namespace Inferno.InfernoScripts.Parupunte
         /// </summary>
         private List<Entity> _autoReleaseEntitiesList = new List<Entity>();
 
-        protected override int TickInterval { get; } = 100;
-
         private UIContainer _mainTextUiContainer;
         private UIContainer _subTextUiContainer;
         private TimerUiTextManager timerText;
@@ -146,7 +144,7 @@ namespace Inferno.InfernoScripts.Parupunte
                 _mainTextUiContainer.Items.Add(timerText.Text);
             });
             //テキストが時間切れしたら消す
-            OnTickAsObservable.Select(_ => timerText.IsEnabled)
+            OnThinnedTickAsObservable.Select(_ => timerText.IsEnabled)
                 .DistinctUntilChanged()
                 .Where(x => !x)
                 .Subscribe(_ => _mainTextUiContainer.Items.Clear());

--- a/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
+++ b/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
@@ -89,8 +89,7 @@ namespace Inferno.InfernoScripts.Parupunte
                 return attribute != null && attribute.IsDebug;
             }).ToArray();
 
-
-
+            
             #endregion ParunteScripts
 
             #region EventHook
@@ -124,7 +123,7 @@ namespace Inferno.InfernoScripts.Parupunte
                 .Select(c => IsonoMethod(c.Command))
                 .Where(x => x)
                 .AsUnitObservable()
-                .ThrottleFirst(TimeSpan.FromSeconds(5))
+                .ThrottleFirst(TimeSpan.FromSeconds(10))
                 .Retry()
                 .Subscribe();
 

--- a/Inferno/InfernoScripts/Parupunte/Scripts/BeastFriends.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/BeastFriends.cs
@@ -11,6 +11,7 @@ using UniRx;
 
 namespace Inferno.InfernoScripts.Parupunte.Scripts
 {
+    [ParupunteIsono("けものふれんず")]
     class BeastFriends : ParupunteScript
     {
         private PedHash[] _animalsHash;

--- a/Inferno/InfernoScripts/Parupunte/Scripts/RpgOnly.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/RpgOnly.cs
@@ -21,10 +21,10 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
             this.OnFinishedAsObservable.Subscribe(_ =>
             {
-                InfernoCore.Publish(ChasoModeEvent.SetToDefault);
+                Inferno.InfernoCore.Publish(ChasoModeEvent.SetToDefault);
             });
 
-            InfernoCore.Publish(new ChangeWeaponEvent(Weapon.RPG));
+            Inferno.InfernoCore.Publish(new ChangeWeaponEvent(Weapon.RPG));
 
         }
     }

--- a/Inferno/InfernoScripts/Parupunte/Scripts/Tempest.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/Tempest.cs
@@ -6,6 +6,7 @@ using UniRx;
 
 namespace Inferno.InfernoScripts.Parupunte.Scripts
 {
+    [ParupunteIsono("てんぺすと")]
     internal class Tempest : ParupunteScript
     {
         private HashSet<Entity> entityList = new HashSet<Entity>();

--- a/Inferno/InfernoScripts/Player/ArmorAndHealthSupplier.cs
+++ b/Inferno/InfernoScripts/Player/ArmorAndHealthSupplier.cs
@@ -17,7 +17,7 @@ namespace Inferno
             OnAllOnCommandObservable.Subscribe(_ => IsActive = true);
 
             //ミッションが始まった時
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => IsActive)
                 .Select(_ => Game.MissionFlag)
                 .DistinctUntilChanged()
@@ -25,7 +25,7 @@ namespace Inferno
                 .Subscribe(_ => SupplyArmorAndHealth());
 
             //プレイヤが復活した時
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => IsActive && PlayerPed.IsSafeExist())
                 .Select(_ => PlayerPed.IsAlive)
                 .DistinctUntilChanged()

--- a/Inferno/InfernoScripts/Player/BondCar.cs
+++ b/Inferno/InfernoScripts/Player/BondCar.cs
@@ -44,7 +44,7 @@ namespace Inferno.InfernoScripts.Player
                     && this.IsGamePadPressed(GameKey.VehicleAttack)
                     && PlayerPed.Weapons.Current.Hash == WeaponHash.Unarmed
                  )
-                .ThrottleFirst(TimeSpan.FromMilliseconds(CoolDownMillSeconds))
+                .ThrottleFirst(TimeSpan.FromMilliseconds(CoolDownMillSeconds), InfernoScriptScheduler)
                 .Subscribe(_ =>
                 {
                     var v = PlayerVehicle.Value;

--- a/Inferno/InfernoScripts/Player/BondCar.cs
+++ b/Inferno/InfernoScripts/Player/BondCar.cs
@@ -37,7 +37,7 @@ namespace Inferno.InfernoScripts.Player
         {
             config = LoadConfig<BondCarConfig>();
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ =>
                     PlayerVehicle.Value.IsSafeExist()
                     && this.IsGamePadPressed(GameKey.VehicleAim)

--- a/Inferno/InfernoScripts/Player/DeathSoundEffect.cs
+++ b/Inferno/InfernoScripts/Player/DeathSoundEffect.cs
@@ -30,7 +30,7 @@ namespace Inferno
             if (filePath.Length > 0)
             {
                 //プレイヤが死亡したら再生
-                OnTickAsObservable
+                OnThinnedTickAsObservable
                     .Select(_ => PlayerPed)
                     .Where(p => p.IsSafeExist())
                     .Select(p => p.IsAlive)

--- a/Inferno/InfernoScripts/Player/DisplayCauseOfDeath.cs
+++ b/Inferno/InfernoScripts/Player/DisplayCauseOfDeath.cs
@@ -1,4 +1,5 @@
-﻿using GTA;
+﻿using System;
+using GTA;
 using GTA.Math;
 using System.Drawing;
 using UniRx;
@@ -29,7 +30,7 @@ namespace Inferno
                 .Where(_ => _mContainer.Items.Count > 0)
                 .Subscribe(_ => _mContainer.Draw());
 
-            CreateTickAsObservable(500)
+            CreateTickAsObservable(TimeSpan.FromSeconds(0.5f))
                .Where(_ => PlayerPed.IsSafeExist())
                 .Select(x => PlayerPed.IsAlive)
                 .DistinctUntilChanged()

--- a/Inferno/InfernoScripts/Player/EmergencyEscape.cs
+++ b/Inferno/InfernoScripts/Player/EmergencyEscape.cs
@@ -34,7 +34,7 @@ namespace Inferno
         {
             conf = LoadConfig<EmergencyEscapeConf>();
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => this.IsGamePadPressed(GameKey.VehicleHorn) && this.IsGamePadPressed(GameKey.VehicleExit))
                 .Subscribe(_ => EscapeVehicle());
         }

--- a/Inferno/InfernoScripts/Player/Floating.cs
+++ b/Inferno/InfernoScripts/Player/Floating.cs
@@ -11,15 +11,13 @@ namespace Inferno.InfernoScripts.Player
     //ふわふわジャンプ
     class Floating : InfernoScript
     {
-        protected override int TickInterval { get; } = 50;
-
         protected override void Setup()
         {
-            this.OnTickAsObservable
+            this.CreateTickAsObservable(TimeSpan.FromMilliseconds(50))
                 .Where(_ => this.IsGamePadPressed(GameKey.Sprint) && this.IsGamePadPressed(GameKey.Jump))
                 .Subscribe(_ =>
                 {
-                    PlayerPed.ApplyForce(Vector3.WorldUp *1.1f );
+                    PlayerPed.ApplyForce(Vector3.WorldUp * 1.1f);
                 });
         }
     }

--- a/Inferno/InfernoScripts/Player/PlayerGripVehicle.cs
+++ b/Inferno/InfernoScripts/Player/PlayerGripVehicle.cs
@@ -19,7 +19,7 @@ namespace Inferno.InfernoScripts.Player
         protected override void Setup()
         {
             //0.3秒間押しっぱなしなら発動
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Select(_ => !this.GetPlayerVehicle().IsSafeExist()
                 && !_isGriped
                 && this.IsGamePadPressed(GameKey.Reload)
@@ -27,14 +27,14 @@ namespace Inferno.InfernoScripts.Player
                 .Where(x => x.All(v => v))
                 .Subscribe(_ => GripAction());
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => _isGriped)
                 .Subscribe(_ =>
                 {
                     Grip(PlayerPed, _vehicle, _ofsetPosition);
                 });
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => _isGriped && (!this.IsGamePadPressed(GameKey.Reload) || PlayerPed.IsDead))
                 .Subscribe(_ => GripRemove());
 

--- a/Inferno/InfernoScripts/Player/PlayerHelthAlert.cs
+++ b/Inferno/InfernoScripts/Player/PlayerHelthAlert.cs
@@ -20,8 +20,6 @@ namespace Inferno
         private int ScreenWidth;
         private int alertHelthValue = 25;
 
-        protected override int TickInterval => 50;
-
         protected override void Setup()
         {
             var screenResolution = NativeFunctions.GetScreenResolution();
@@ -34,7 +32,9 @@ namespace Inferno
             OnDrawingTickAsObservable
                 .Subscribe(_ => _mContainer.Draw());
 
-            OnTickAsObservable
+            var harlThinned = CreateTickAsObservable(TimeSpan.FromMilliseconds(50));
+
+            harlThinned
                 .Where(_ => PlayerPed.IsSafeExist() && PlayerPed.Health < alertHelthValue && PlayerPed.IsAlive)
                 .Subscribe(_ =>
                 {
@@ -48,7 +48,7 @@ namespace Inferno
                     _mContainer.Items.Add(rect);
                 });
 
-            OnTickAsObservable
+            harlThinned
                 .Select(_ => PlayerPed.IsSafeExist() && PlayerPed.Health < alertHelthValue)
                 .DistinctUntilChanged()
                 .Where(x => !x)

--- a/Inferno/InfernoScripts/Player/PlayerRagdoll.cs
+++ b/Inferno/InfernoScripts/Player/PlayerRagdoll.cs
@@ -1,4 +1,5 @@
-﻿using GTA;
+﻿using System;
+using GTA;
 using UniRx;
 
 namespace Inferno
@@ -8,14 +9,10 @@ namespace Inferno
     /// </summary>
     public class PlayerRagdoll : InfernoScript
     {
-        protected override int TickInterval
-        {
-            get { return 50; }
-        }
 
         protected override void Setup()
         {
-            OnTickAsObservable
+            CreateTickAsObservable(TimeSpan.FromMilliseconds(50))
                     .Where(_ => this.IsGamePadPressed(GameKey.Stealth) && this.IsGamePadPressed(GameKey.Jump))
                     .Subscribe(_ =>
                     {

--- a/Inferno/InfernoScripts/Player/PlayerVehicleNitro.cs
+++ b/Inferno/InfernoScripts/Player/PlayerVehicleNitro.cs
@@ -34,8 +34,6 @@ namespace Inferno
 
         private bool _isNitroOk = true;
 
-        protected override int TickInterval => 50;
-
         private float StraightAccelerationSpeed => conf?.StraightAccelerationSpeed ?? 50;
         private float JumpAccelerationSpeed => conf?.JumpAccelerationSpeed ?? 20;
         private float CoolDownSeconds => conf?.CoolDownSeconds ?? 10.0f;
@@ -45,7 +43,7 @@ namespace Inferno
             conf = LoadConfig<PlayerNitroConf>();
 
             IsActive = true;
-            OnTickAsObservable
+            CreateTickAsObservable(TimeSpan.FromMilliseconds(50))
                 .Where(
                     _ =>
                         _isNitroOk && this.IsGamePadPressed(GameKey.VehicleAccelerate) && this.IsGamePadPressed(GameKey.VehicleHandbrake) &&

--- a/Inferno/InfernoScripts/Player/SpecialAbilityBgm.cs
+++ b/Inferno/InfernoScripts/Player/SpecialAbilityBgm.cs
@@ -30,7 +30,7 @@ namespace Inferno
 
             OnAllOnCommandObservable.Subscribe(_ => IsActive = true);
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => IsActive && (uint)PlayerPed.Model.Hash == (uint)PedHash.Trevor)
                 .Select(_ => Game.Player.IsSpecialAbilityActive() && PlayerPed.IsAlive)
                 .DistinctUntilChanged()

--- a/Inferno/InfernoScripts/World/Fulton.cs
+++ b/Inferno/InfernoScripts/World/Fulton.cs
@@ -15,7 +15,6 @@ namespace Inferno
 {
     internal class Fulton : InfernoScript
     {
-        protected override int TickInterval { get; } = 100;
 
         /// <summary>
         /// フルトン回収のコルーチン対象になっているEntity
@@ -43,6 +42,7 @@ namespace Inferno
 
         protected override void Setup()
         {
+
             CreateInputKeywordAsObservable("fulton")
                 .Subscribe(_ =>
                 {
@@ -60,12 +60,12 @@ namespace Inferno
                 .Where(x => IsActive && x.KeyCode == Keys.F10 && motherBasePeds.Count > 0)
                 .Subscribe(_ => SpawnCitizen());
 
-            CreateTickAsObservable(500)
+            CreateTickAsObservable(TimeSpan.FromSeconds(0.5))
                 .Where(_ => IsActive && !Function.Call<bool>(Hash.IS_CUTSCENE_ACTIVE))
                 .Subscribe(_ => FulutonUpdate());
 
             //プレイヤが死んだらリストクリア
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Select(_ => PlayerPed.IsDead)
                 .DistinctUntilChanged()
                 .Where(x => x)
@@ -185,7 +185,7 @@ namespace Inferno
             foreach (var s in WaitForSeconds(3))
             {
                 if (!entity.IsSafeExist() || entity.IsDead) yield break;
-                if(entity is Ped) { ((Ped)entity).SetToRagdoll(); }
+                if (entity is Ped) { ((Ped)entity).SetToRagdoll(); }
                 entity.ApplyForce(upForce * 1.07f);
 
                 yield return s;
@@ -270,7 +270,7 @@ namespace Inferno
         /// </summary>
         private IEnumerable<object> FriendCoroutine(Ped ped)
         {
-            while (ped.IsSafeExist() && ped.IsAlive && ped.IsInRangeOf(PlayerPed.Position,100))
+            while (ped.IsSafeExist() && ped.IsAlive && ped.IsInRangeOf(PlayerPed.Position, 100))
             {
                 yield return WaitForSeconds(1);
             }
@@ -279,7 +279,7 @@ namespace Inferno
                 ped.MarkAsNoLongerNeeded();
             }
         }
-             
+
         private void SpawnVehicle()
         {
             var hash = motherbaseVeh.Dequeue();

--- a/Inferno/InfernoScripts/World/Meteo.cs
+++ b/Inferno/InfernoScripts/World/Meteo.cs
@@ -76,7 +76,7 @@ namespace Inferno
                     }
                 });
 
-            CreateTickAsObservable(DurationMillSeconds)
+            CreateTickAsObservable(TimeSpan.FromMilliseconds(DurationMillSeconds))
                .Where(_ => IsActive && Random.Next(0, 100) <= Probability)
                 .Subscribe(_ => ShootMeteo());
         }

--- a/Inferno/InfernoScripts/World/SpeedMax.cs
+++ b/Inferno/InfernoScripts/World/SpeedMax.cs
@@ -51,7 +51,7 @@ namespace Inferno.InfernoScripts.World
             //ミッション開始直後に一瞬動作を止めるフラグ
             var suspednFlag = false;
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => IsActive && !suspednFlag)
                 .Subscribe(_ =>
                 {
@@ -102,7 +102,7 @@ namespace Inferno.InfernoScripts.World
                     DrawText($"SpeedMax:ExcludeMissionVehicles[{excludeMissionVehicle}]");
                 });
 
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => IsActive)
                 .Select(_ => PlayerPed.IsAlive)
                 .DistinctUntilChanged()
@@ -110,7 +110,7 @@ namespace Inferno.InfernoScripts.World
                 .Subscribe(_ => vehicleHashSet.Clear());
 
             //ミッションが始まった時にしばらく動作を止める
-            OnTickAsObservable
+            OnThinnedTickAsObservable
                 .Where(_ => IsActive)
                 .Select(_ => Game.MissionFlag)
                 .DistinctUntilChanged()

--- a/Inferno/Utilities/PriorityQueue.cs
+++ b/Inferno/Utilities/PriorityQueue.cs
@@ -1,0 +1,148 @@
+﻿// this code is borrowed from RxOfficial(rx.codeplex.com) and modified
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Inferno.Utilities
+{
+    internal class PriorityQueue<T> where T : IComparable<T>
+    {
+        private static long _count = long.MinValue;
+
+        private IndexedItem[] _items;
+        private int _size;
+
+        public PriorityQueue()
+            : this(16)
+        {
+        }
+
+        public PriorityQueue(int capacity)
+        {
+            _items = new IndexedItem[capacity];
+            _size = 0;
+        }
+
+        private bool IsHigherPriority(int left, int right)
+        {
+            return _items[left].CompareTo(_items[right]) < 0;
+        }
+
+        private void Percolate(int index)
+        {
+            if (index >= _size || index < 0)
+                return;
+            var parent = (index - 1) / 2;
+            if (parent < 0 || parent == index)
+                return;
+
+            if (IsHigherPriority(index, parent))
+            {
+                var temp = _items[index];
+                _items[index] = _items[parent];
+                _items[parent] = temp;
+                Percolate(parent);
+            }
+        }
+
+        private void Heapify()
+        {
+            Heapify(0);
+        }
+
+        private void Heapify(int index)
+        {
+            if (index >= _size || index < 0)
+                return;
+
+            var left = 2 * index + 1;
+            var right = 2 * index + 2;
+            var first = index;
+
+            if (left < _size && IsHigherPriority(left, first))
+                first = left;
+            if (right < _size && IsHigherPriority(right, first))
+                first = right;
+            if (first != index)
+            {
+                var temp = _items[index];
+                _items[index] = _items[first];
+                _items[first] = temp;
+                Heapify(first);
+            }
+        }
+
+        public int Count { get { return _size; } }
+
+        public T Peek()
+        {
+            if (_size == 0)
+                throw new InvalidOperationException("HEAP is Empty");
+
+            return _items[0].Value;
+        }
+
+        private void RemoveAt(int index)
+        {
+            _items[index] = _items[--_size];
+            _items[_size] = default(IndexedItem);
+            Heapify();
+            if (_size < _items.Length / 4)
+            {
+                var temp = _items;
+                _items = new IndexedItem[_items.Length / 2];
+                Array.Copy(temp, 0, _items, 0, _size);
+            }
+        }
+
+        public T Dequeue()
+        {
+            var result = Peek();
+            RemoveAt(0);
+            return result;
+        }
+
+        public void Enqueue(T item)
+        {
+            if (_size >= _items.Length)
+            {
+                var temp = _items;
+                _items = new IndexedItem[_items.Length * 2];
+                Array.Copy(temp, _items, temp.Length);
+            }
+
+            var index = _size++;
+            _items[index] = new IndexedItem { Value = item, Id = Interlocked.Increment(ref _count) };
+            Percolate(index);
+        }
+
+        public bool Remove(T item)
+        {
+            for (var i = 0; i < _size; ++i)
+            {
+                if (EqualityComparer<T>.Default.Equals(_items[i].Value, item))
+                {
+                    RemoveAt(i);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        struct IndexedItem : IComparable<IndexedItem>
+        {
+            public T Value;
+            public long Id;
+
+            public int CompareTo(IndexedItem other)
+            {
+                var c = Value.CompareTo(other.Value);
+                if (c == 0)
+                    c = Id.CompareTo(other.Id);
+                return c;
+            }
+        }
+    }
+}

--- a/Inferno/Utilities/ScheduledItem.cs
+++ b/Inferno/Utilities/ScheduledItem.cs
@@ -1,0 +1,258 @@
+﻿// this code is borrowed from RxOfficial(rx.codeplex.com) and modified
+
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using UniRx;
+
+namespace Inferno.Utilities
+{
+    /// <summary>
+    /// Abstract base class for scheduled work items.
+    /// </summary>
+    internal class ScheduledItem : IComparable<ScheduledItem>
+    {
+        private readonly BooleanDisposable _disposable = new BooleanDisposable();
+        private readonly TimeSpan _dueTime;
+        private readonly Action _action;
+
+        /// <summary>
+        /// Creates a new scheduled work item to run at the specified time.
+        /// </summary>
+        /// <param name="dueTime">Absolute time at which the work item has to be executed.</param>
+        public ScheduledItem(Action action, TimeSpan dueTime)
+        {
+            _dueTime = dueTime;
+            _action = action;
+        }
+
+        /// <summary>
+        /// Gets the absolute time at which the item is due for invocation.
+        /// </summary>
+        public TimeSpan DueTime
+        {
+            get { return _dueTime; }
+        }
+
+        /// <summary>
+        /// Invokes the work item.
+        /// </summary>
+        public void Invoke()
+        {
+            if (!_disposable.IsDisposed)
+            {
+                _action();
+            }
+        }
+
+        #region Inequality
+
+        /// <summary>
+        /// Compares the work item with another work item based on absolute time values.
+        /// </summary>
+        /// <param name="other">Work item to compare the current work item to.</param>
+        /// <returns>Relative ordering between this and the specified work item.</returns>
+        /// <remarks>The inequality operators are overloaded to provide results consistent with the IComparable implementation. Equality operators implement traditional reference equality semantics.</remarks>
+        public int CompareTo(ScheduledItem other)
+        {
+            // MSDN: By definition, any object compares greater than null, and two null references compare equal to each other. 
+            if (ReferenceEquals(other, null))
+                return 1;
+
+            return DueTime.CompareTo(other.DueTime);
+        }
+
+        /// <summary>
+        /// Determines whether one specified ScheduledItem&lt;TAbsolute&gt; object is due before a second specified ScheduledItem&lt;TAbsolute&gt; object.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if the DueTime value of left is earlier than the DueTime value of right; otherwise, false.</returns>
+        /// <remarks>This operator provides results consistent with the IComparable implementation.</remarks>
+        public static bool operator <(ScheduledItem left, ScheduledItem right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified ScheduledItem&lt;TAbsolute&gt; object is due before or at the same of a second specified ScheduledItem&lt;TAbsolute&gt; object.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if the DueTime value of left is earlier than or simultaneous with the DueTime value of right; otherwise, false.</returns>
+        /// <remarks>This operator provides results consistent with the IComparable implementation.</remarks>
+        public static bool operator <=(ScheduledItem left, ScheduledItem right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified ScheduledItem&lt;TAbsolute&gt; object is due after a second specified ScheduledItem&lt;TAbsolute&gt; object.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if the DueTime value of left is later than the DueTime value of right; otherwise, false.</returns>
+        /// <remarks>This operator provides results consistent with the IComparable implementation.</remarks>
+        public static bool operator >(ScheduledItem left, ScheduledItem right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /// <summary>
+        /// Determines whether one specified ScheduledItem&lt;TAbsolute&gt; object is due after or at the same time of a second specified ScheduledItem&lt;TAbsolute&gt; object.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if the DueTime value of left is later than or simultaneous with the DueTime value of right; otherwise, false.</returns>
+        /// <remarks>This operator provides results consistent with the IComparable implementation.</remarks>
+        public static bool operator >=(ScheduledItem left, ScheduledItem right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
+
+        #endregion
+
+        #region Equality
+
+        /// <summary>
+        /// Determines whether two specified ScheduledItem&lt;TAbsolute, TValue&gt; objects are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if both ScheduledItem&lt;TAbsolute, TValue&gt; are equal; otherwise, false.</returns>
+        /// <remarks>This operator does not provide results consistent with the IComparable implementation. Instead, it implements reference equality.</remarks>
+        public static bool operator ==(ScheduledItem left, ScheduledItem right)
+        {
+            return ReferenceEquals(left, right);
+        }
+
+        /// <summary>
+        /// Determines whether two specified ScheduledItem&lt;TAbsolute, TValue&gt; objects are inequal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if both ScheduledItem&lt;TAbsolute, TValue&gt; are inequal; otherwise, false.</returns>
+        /// <remarks>This operator does not provide results consistent with the IComparable implementation. Instead, it implements reference equality.</remarks>
+        public static bool operator !=(ScheduledItem left, ScheduledItem right)
+        {
+            return !(left == right);
+        }
+
+        /// <summary>
+        /// Determines whether a ScheduledItem&lt;TAbsolute&gt; object is equal to the specified object.
+        /// </summary>
+        /// <param name="obj">The object to compare to the current ScheduledItem&lt;TAbsolute&gt; object.</param>
+        /// <returns>true if the obj parameter is a ScheduledItem&lt;TAbsolute&gt; object and is equal to the current ScheduledItem&lt;TAbsolute&gt; object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            return ReferenceEquals(this, obj);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the current ScheduledItem&lt;TAbsolute&gt; object.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        #endregion
+
+        public IDisposable Cancellation
+        {
+            get
+            {
+                return _disposable;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the work item has received a cancellation request.
+        /// </summary>
+        public bool IsCanceled
+        {
+            get { return _disposable.IsDisposed; }
+        }
+    }
+
+    /// <summary>
+    /// Efficient scheduler queue that maintains scheduled items sorted by absolute time.
+    /// </summary>
+    /// <remarks>This type is not thread safe; users should ensure proper synchronization.</remarks>
+    [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification = "But it *is* a queue!")]
+    internal class SchedulerQueue
+    {
+        private readonly PriorityQueue<ScheduledItem> _queue;
+
+        /// <summary>
+        /// Creates a new scheduler queue with a default initial capacity.
+        /// </summary>
+        public SchedulerQueue()
+            : this(1024)
+        {
+        }
+
+        /// <summary>
+        /// Creats a new scheduler queue with the specified initial capacity.
+        /// </summary>
+        /// <param name="capacity">Initial capacity of the scheduler queue.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
+        public SchedulerQueue(int capacity)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity");
+
+            _queue = new PriorityQueue<ScheduledItem>(capacity);
+        }
+
+        /// <summary>
+        /// Gets the number of scheduled items in the scheduler queue.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return _queue.Count;
+            }
+        }
+
+        /// <summary>
+        /// Enqueues the specified work item to be scheduled.
+        /// </summary>
+        /// <param name="scheduledItem">Work item to be scheduled.</param>
+        public void Enqueue(ScheduledItem scheduledItem)
+        {
+            _queue.Enqueue(scheduledItem);
+        }
+
+        /// <summary>
+        /// Removes the specified work item from the scheduler queue.
+        /// </summary>
+        /// <param name="scheduledItem">Work item to be removed from the scheduler queue.</param>
+        /// <returns>true if the item was found; false otherwise.</returns>
+        public bool Remove(ScheduledItem scheduledItem)
+        {
+            return _queue.Remove(scheduledItem);
+        }
+
+        /// <summary>
+        /// Dequeues the next work item from the scheduler queue.
+        /// </summary>
+        /// <returns>Next work item in the scheduler queue (removed).</returns>
+        public ScheduledItem Dequeue()
+        {
+            return _queue.Dequeue();
+        }
+
+        /// <summary>
+        /// Peeks the next work item in the scheduler queue.
+        /// </summary>
+        /// <returns>Next work item in the scheduler queue (not removed).</returns>
+        public ScheduledItem Peek()
+        {
+            return _queue.Peek();
+        }
+    }
+}

--- a/InfernoTest/InfernoTest.csproj
+++ b/InfernoTest/InfernoTest.csproj
@@ -58,9 +58,6 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="ScriptHookVDotNet">
-      <HintPath>..\ScriptHookVDotNet.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>


### PR DESCRIPTION
自前で秒数を測ったり、Intervalの実行回数で時間を見積もったりしていた部分を全てShcedulerに統一しました

また、コルーチンの実行を分散させることでカクつきを減らしました。
具体的にはコルーチンを100msごとにまとめて実行という実装から、5個のCoroutineSystemを20msごとに順番に実行する形式にしました。