### PR TITLE
手配度変更パルプンテが例外で落ちることがあるバグを修正

### DIFF
--- a/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
@@ -6,7 +6,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
     internal class ChangeWantedLevel : ParupunteScript
     {
         private int wantedLevelThreshold = 1;
-        private int wantedLevel = Game.Player.WantedLevel;
+        private int wantedLevel;
 
         public ChangeWantedLevel(ParupunteCore core, ParupunteConfigElement element) : base(core, element)
         {
@@ -21,6 +21,9 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
         public override void OnStart()
         {
+            //確実にメインスレッドで取得するためにここで取得
+            wantedLevel = Game.Player.WantedLevel;
+
             if (wantedLevel >= wantedLevelThreshold)
             {
                 Game.Player.WantedLevel = 0;


### PR DESCRIPTION
SHVDNの高速化したらできたバグでもあったかなって思ってたけど、SHVDNのソースをちょっと変えて`nativeCall`の戻り値を確認したらnullだったからこっちの書き方の問題だと確信できた。
まさかメインスレッド以外でネイティブ関数を呼ぼうとしたらSHV側の`nativeCall`がnullで返してくるなんて…