### PR TITLE
対象のフレームワークを4.8に変更

### DIFF
--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Inferno</RootNamespace>
     <AssemblyName>Inferno</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <TargetFrameworkProfile />

--- a/InfernoTest/InfernoTest.csproj
+++ b/InfernoTest/InfernoTest.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InfernoTest</RootNamespace>
     <AssemblyName>InfernoTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>


### PR DESCRIPTION
[SHVDNのv2.10.10](https://github.com/crosire/scripthookvdotnet/releases/tag/v2.10.10)から対象のフレームワークを4.8に上げたのでその都合で。SHVDNがスクリプト側の対象のフレームワークの設定に関係なくインストールしてる.NET Framework 4のバージョンで動かしていて、スクリプトの互換性は壊していないことは確認しています。