### PR TITLE
Fix 202508

### DIFF
--- a/Inferno/ChaosMode/ChaosMode.cs
+++ b/Inferno/ChaosMode/ChaosMode.cs
@@ -223,7 +223,7 @@ namespace Inferno.ChaosMode
 
             //まだ処理をしていない市民を対象とする
             var nearPeds =
-                CachedPeds.Where(x => x.IsSafeExist() && x.IsInRangeOf(PlayerPed.Position, _chaosModeSetting.Radius));
+                CachedPeds.Where(x => x.IsSafeExist() && x.IsHuman && x.IsInRangeOf(PlayerPed.Position, _chaosModeSetting.Radius));
 
             _localCts ??= new CancellationTokenSource();
             _linkedCts ??=

--- a/Inferno/ExtensionMethods/ExtensionMethods.cs
+++ b/Inferno/ExtensionMethods/ExtensionMethods.cs
@@ -256,7 +256,7 @@ namespace Inferno
                 // 同じグループ
                 return true;
             }
-            
+
             // プレイヤーとの関係（Companion/Respect/Like）
             int rel = Function.Call<int>(Hash.GET_RELATIONSHIP_BETWEEN_PEDS, ped.Handle, player.Handle);
             // SHVDN の Relationship enum: Companion=0, Respect=1, Like=2, Neutral=3, Dislike=4, Hate=5
@@ -310,6 +310,14 @@ namespace Inferno
                 PedType.PED_TYPE_ARMY => true,
                 _ => CopPedHas.Contains((PedHash)ped.Model.Hash)
             };
+        }
+
+        public static IEnumerable<T> Around<T>(this IEnumerable<T> entities, Entity target, float range)
+            where T : Entity
+        {
+            if (!target.IsSafeExist()) return Array.Empty<T>();
+            var pos = target.Position;
+            return entities.Where(x => x.IsSafeExist() && x.IsInRangeOf(pos, range));
         }
 
         #region Weapon

--- a/Inferno/ExtensionMethods/ExtensionMethods.cs
+++ b/Inferno/ExtensionMethods/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GTA;
 using GTA.Math;
@@ -216,6 +217,69 @@ namespace Inferno
         public static PedType GetPedType(this Ped p)
         {
             return Function.Call<PedType>(Hash.GET_PED_TYPE, p.Handle);
+        }
+
+        // 追従・同行を示しやすいタスク一覧（必要に応じて拡張）
+        private static readonly HashSet<Hash> FollowishTasks = new HashSet<Hash>
+        {
+            Hash.TASK_FOLLOW_TO_OFFSET_OF_ENTITY,
+            Hash.TASK_GO_TO_ENTITY,
+            Hash.TASK_ENTER_VEHICLE,
+            Hash.TASK_GOTO_ENTITY_OFFSET,
+            Hash.TASK_VEHICLE_ESCORT, // 同行の車列
+        };
+
+        private static bool IsTaskActive(Ped ped, Hash taskHash)
+        {
+            var status = Function.Call<int>(Hash.GET_SCRIPT_TASK_STATUS, ped.Handle, taskHash);
+            // 0: PENDING, 1: IN_PROGRESS, 7: FINISHED（ことが多い）
+            return status == 0 || status == 1;
+        }
+
+
+        public static bool MayBeFriend(this Ped ped)
+        {
+            if (!ped.IsSafeExist()) return false;
+
+            var player = Game.Player;
+
+            var playerPed = Game.Player.Character;
+            // 同乗（プレイヤー運転車に同乗)
+            if (ped.IsInVehicle() && playerPed.IsInVehicle() && ped.CurrentVehicle == playerPed.CurrentVehicle)
+            {
+                return true;
+            }
+
+            var playerGroup = Function.Call<int>(Hash.GET_PLAYER_GROUP, player.Handle);
+            if (Function.Call<bool>(Hash.IS_PED_GROUP_MEMBER, ped.Handle, playerGroup))
+            {
+                // 同じグループ
+                return true;
+            }
+            
+            // プレイヤーとの関係（Companion/Respect/Like）
+            int rel = Function.Call<int>(Hash.GET_RELATIONSHIP_BETWEEN_PEDS, ped.Handle, player.Handle);
+            // SHVDN の Relationship enum: Companion=0, Respect=1, Like=2, Neutral=3, Dislike=4, Hate=5
+            if (rel <= 2) return true;
+
+            // 5) ブリップが友好色
+            var blip = ped.AttachedBlip;
+            if (blip != null && blip.Exists())
+            {
+                if (blip.Color != BlipColor.Red && blip.Color != BlipColor.Red2 && blip.Color != BlipColor.Red3 &&
+                    blip.Color != BlipColor.Red4)
+                {
+                    return true;
+                }
+            }
+
+            // 追跡系のタスク実行中か
+            foreach (var t in FollowishTasks)
+            {
+                if (IsTaskActive(ped, t)) return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -118,6 +118,7 @@
         <Compile Include="InfernoScripts\InfernoCore\UI\InfernoUI.cs" />
         <Compile Include="InfernoScripts\InfernoCore\UI\IScriptUiBuilder.cs" />
         <Compile Include="InfernoScripts\InfernoCore\UI\IUiHelper.cs" />
+        <Compile Include="InfernoScripts\Parupunte\Scripts\EveryoneFart.cs" />
         <Compile Include="InfernoScripts\Parupunte\Scripts\RotateSushi.cs" />
         <Compile Include="InfernoScripts\Players\AutoHealPlayerHealth.cs" />
         <Compile Include="InfernoScripts\Players\SuppressWanted.cs" />

--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -221,6 +221,7 @@
         <Compile Include="InfernoScripts\Players\Warp.cs" />
         <Compile Include="InfernoScripts\Worlds\ChaosAirPlane.cs" />
         <Compile Include="InfernoScripts\Worlds\ChaosHeli.cs" />
+        <Compile Include="InfernoScripts\Worlds\ChaoticCutscene.cs" />
         <Compile Include="InfernoScripts\Worlds\Fulton.cs" />
         <Compile Include="InfernoScripts\Worlds\Meteor.cs" />
         <Compile Include="InfernoScripts\Worlds\SpeedMax.cs" />

--- a/Inferno/Inferno.csproj
+++ b/Inferno/Inferno.csproj
@@ -109,6 +109,7 @@
         <Compile Include="ChaosMode\WeaponProvider\CustomWeaponProvider.cs"/>
         <Compile Include="ChaosMode\WeaponProvider\SingleWeaponProvider.cs"/>
         <Compile Include="ExtensionMethods\NativeFunctions.cs"/>
+        <Compile Include="InfernoScripts\Citizen\CitizenForceRide.cs" />
         <Compile Include="InfernoScripts\Conf\InfernoCommandConfig.cs" />
         <Compile Include="InfernoScripts\InfernoCore\Drawer\UI\UIRectangle.cs" />
         <Compile Include="InfernoScripts\InfernoCore\InfernoAllOnProvider.cs" />

--- a/Inferno/InfernoScripts/Citizen/CitizenForceRide.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenForceRide.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GTA;
+using Inferno.ChaosMode;
+using Inferno.InfernoScripts.InfernoCore.UI;
+using Inferno.Properties;
+using Inferno.Utilities;
+using LemonUI;
+using LemonUI.Menus;
+
+namespace Inferno
+{
+    public sealed class CitizenForceRide : InfernoScript
+    {
+        private CompositeDisposable _activationDisposable;
+
+        private HashSet<int> _processingPeds;
+
+        private ForceRideConfig _config;
+
+        protected override string ConfigFileName { get; } = "ForceRide.conf";
+
+        protected override void Setup()
+        {
+            _config ??= LoadConfig<ForceRideConfig>();
+
+            CreateInputKeywordAsObservable("ForceRide", "forceride")
+                .Subscribe(_ =>
+                {
+                    IsActive = !IsActive;
+                    DrawText("ForceRide:" + IsActive);
+                });
+
+            IsActiveRP.Subscribe(x =>
+            {
+                if (x)
+                {
+                    Activated();
+                }
+                else
+                {
+                    Deactivated();
+                }
+            });
+        }
+
+        private void Activated()
+        {
+            _processingPeds ??= new HashSet<int>();
+            _activationDisposable?.Dispose();
+            _activationDisposable = new CompositeDisposable();
+            
+            var hornPressed = OnTickAsObservable
+                .Select(_ => Game.IsControlJustPressed(Control.VehicleHorn))
+                .DistinctUntilChanged()
+                .Where(s => s);
+
+            hornPressed
+                .Buffer(() => hornPressed.Throttle(TimeSpan.FromSeconds(_config.Period), InfernoScheduler))
+                .Where(buf => buf.Count >= _config.Hit)
+                .Subscribe(_ => RideAroundPedOnPlayerVehicle())
+                .AddTo(_activationDisposable);
+        }
+
+        private void Deactivated()
+        {
+            _activationDisposable?.Dispose();
+            _activationDisposable = null;
+            _processingPeds?.Clear();
+            _processingPeds = null;
+        }
+
+        private void RideAroundPedOnPlayerVehicle()
+        {
+            if (!PlayerPed.IsInVehicle()) return;
+            if (!IsActive) return;
+            
+            DrawTextL("Force ride!");
+
+            // 周辺市民の探索
+            var aroundPeds = CachedPeds.Around(PlayerPed, 10f)
+                .Where(x => !x.IsInVehicle() && !_processingPeds.Contains(x.Handle))
+                .ToArray();
+
+            // ミッション対象者がいるならその人を最優先
+            var missionCharacter = aroundPeds.FirstOrDefault(x => x.IsRequiredForMission());
+            if (missionCharacter.IsSafeExist())
+            {
+                ObservePedToVehicleAsync(missionCharacter, ActivationCancellationToken).Forget();
+                return;
+            }
+
+            foreach (var ped in aroundPeds)
+            {
+                ObservePedToVehicleAsync(ped, ActivationCancellationToken).Forget();
+            }
+        }
+
+
+        /// <summary>
+        /// 対象市民をPlayerが乗っている車にのせる
+        /// </summary>
+        private async ValueTask ObservePedToVehicleAsync(Ped ped, CancellationToken ct)
+        {
+            if (!PlayerPed.IsInVehicle()) return;
+            if (!_processingPeds.Add(ped.Handle)) return;
+
+            try
+            {
+                ped.SetNotChaosPed(true);
+                ped.AlwaysKeepTask = false;
+                ped.BlockPermanentEvents = true;
+                ped.Task.ClearAllImmediately();
+                ped.Task.ClearSecondary();
+                ped.Task.ClearLookAt();
+
+
+                var playerVehicle = PlayerPed.CurrentVehicle;
+                if (!playerVehicle.IsSafeExist()) return;
+
+                // たまに運転席
+                var targetSeat = Random.Next(0, 100) < 10 ? VehicleSeat.Driver : VehicleSeat.Any;
+
+                var retryCount = 5;
+                // 車に乗るまでリトライ
+                while (ped.IsSafeExist() && !ped.IsGettingIntoVehicle && PlayerPed.IsInVehicle())
+                {
+                    // 中止
+                    if (retryCount == 0) return;
+                    ped.Task.EnterVehicle(playerVehicle, targetSeat, -1, 2.0f,
+                        EnterVehicleFlags.JackAnyone | EnterVehicleFlags.ResumeIfInterupted);
+
+                    await DelaySecondsAsync(1, ct);
+                    retryCount--;
+                }
+
+                if (!ped.IsSafeExist()) return;
+
+
+                // 車に乗るまで監視
+                while (ped.IsSafeExist() && !ped.IsInVehicle() && ped.IsGettingIntoVehicle && PlayerPed.IsInVehicle() &&
+                       !ct.IsCancellationRequested)
+                {
+                    if (!ped.IsAlive) return;
+                    await DelaySecondsAsync(1, ct);
+                }
+            }
+            finally
+            {
+                if (ped.IsSafeExist())
+                {
+                    ped.BlockPermanentEvents = false;
+                    ped.SetNotChaosPed(false);
+                }
+
+                _processingPeds?.Remove(ped.Handle);
+            }
+        }
+
+        public override bool UseUI => true;
+        public override string DisplayName => EntitiesLocalize.ForceRideTitle;
+
+        public override string Description => EntitiesLocalize.ForceRideDescription;
+
+        public override bool CanChangeActive => true;
+
+        public override MenuIndex MenuIndex => MenuIndex.Entities;
+
+        [Serializable]
+        private class ForceRideConfig : InfernoConfig
+        {
+            private int _hit = 3;
+            private float _period = 2.0f;
+
+            public int Hit
+            {
+                get => _hit;
+                set => _hit = value.Clamp(2, 10);
+            }
+
+            public float Period
+            {
+                get => _period;
+                set => _period = value.Clamp(1f, 10f);
+            }
+
+            public override bool Validate()
+            {
+                if (_period < 1) return false;
+                if (_period > 10) return false;
+                if (_hit < 2) return false;
+                if (_hit > 10) return false;
+                return true;
+            }
+        }
+
+
+
+        public override void OnUiMenuConstruct(ObjectPool pool, NativeMenu subMenu)
+        {
+            _config ??= LoadConfig<ForceRideConfig>();
+
+            var button = subMenu.AddButton(EntitiesLocalize.ForceRideAction, "",
+                _ =>
+                {
+                    InfernoSynchronizationContext.Post(_=> RideAroundPedOnPlayerVehicle(), null);
+                });
+
+            IsActiveRP.Subscribe(x => button.Enabled = x);
+
+            subMenu.AddSlider(
+                $"Input timeout: {_config.Period}[s]",
+                EntitiesLocalize.ForceRideInputTimeout,
+                (int)(10 * _config.Period),
+                100,
+                x =>
+                {
+                    x.Value = (int)(10 * _config.Period);
+                    x.Multiplier = 1;
+                }, item =>
+                {
+                    var next = item.Value / 10f;
+                    if (Math.Abs(next - _config.Period) > 0.001f)
+                    {
+                        IsActive = false;
+                    }
+
+                    _config.Period = next;
+                    item.Title = $"Input timeout: {_config.Period}[s]";
+                });
+
+            subMenu.AddSlider(
+                $"Require hits: {_config.Hit}",
+                EntitiesLocalize.ForceRideInputCount,
+                _config.Hit,
+                10,
+                x =>
+                {
+                    x.Value = _config.Hit;
+                    x.Multiplier = 1;
+                }, item =>
+                {
+                    var next = item.Value;
+                    if (next != _config.Hit)
+                    {
+                        IsActive = false;
+                    }
+
+                    _config.Hit = item.Value;
+                    item.Title = $"Require hits: {_config.Hit}";
+                });
+
+
+            subMenu.AddButton(InfernoCommon.DefaultValue, "", _ =>
+            {
+                _config = LoadDefaultConfig<ForceRideConfig>();
+                subMenu.Visible = false;
+                subMenu.Visible = true;
+            });
+
+            subMenu.AddButton(InfernoCommon.SaveConf, InfernoCommon.SaveConfDescription, _ =>
+            {
+                SaveConfig(_config);
+                DrawText($"Saved to {ConfigFileName}");
+            });
+        }
+    }
+}

--- a/Inferno/InfernoScripts/Citizen/CitizenNitro.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenNitro.cs
@@ -71,7 +71,8 @@ namespace Inferno
                 var nitroAvailableVehs = CachedVehicles
                     .Where(x => (!playerVehicle.IsSafeExist() || x != playerVehicle) &&
                                 x.IsInRangeOfIgnoreZ(PlayerPed.Position, config.Range) &&
-                                x.GetPedOnSeat(VehicleSeat.Driver).IsSafeExist() && !x.IsPersistent);
+                                x.GetPedOnSeat(VehicleSeat.Driver).IsSafeExist() && !x.IsPersistent &&
+                                x.IsAlive);
 
                 foreach (var veh in nitroAvailableVehs)
                 {

--- a/Inferno/InfernoScripts/Citizen/CitizenRobberVehicle.cs
+++ b/Inferno/InfernoScripts/Citizen/CitizenRobberVehicle.cs
@@ -72,14 +72,13 @@ namespace Inferno
             {
                 return;
             }
-
-            var playerVehicle = this.GetPlayerVehicle();
-
+            
             //プレイヤの周辺の市民
             var targetPeds = CachedPeds.Where(x => x.IsSafeExist()
                                                    && x.IsAlive
                                                    && x.IsInRangeOf(PlayerPed.Position, PlayerAroundDistance)
                                                    && x != PlayerPed
+                                                   && x.IsHuman
                                                    && !x.IsRequiredForMission()
                                                    && !_robbingPeds.Contains(x));
 

--- a/Inferno/InfernoScripts/InfernoCore/InfernoScript.cs
+++ b/Inferno/InfernoScripts/InfernoCore/InfernoScript.cs
@@ -233,7 +233,7 @@ namespace Inferno
                     }
                     catch (Exception e)
                     {
-                        LogWrite(e.ToString());
+                        LogWrite($"{e}\n{e.StackTrace}");
                     }
 
                     try

--- a/Inferno/InfernoScripts/InfernoCore/Isono/IsonoHttpServer.cs
+++ b/Inferno/InfernoScripts/InfernoCore/Isono/IsonoHttpServer.cs
@@ -11,6 +11,8 @@ namespace Inferno
         private readonly int _port;
         public IObservable<IsonoMessage> OnReceivedMessageAsObservable => _subject;
         private readonly Subject<IsonoMessage> _subject = new();
+        
+        public bool IsDisposed { get; private set; }
 
         public IsonoHttpServer(int port)
         {
@@ -38,6 +40,7 @@ namespace Inferno
             _listener?.Dispose();
             _subject?.OnCompleted();
             _subject?.Dispose();
+            IsDisposed = true;
         }
     }
 }

--- a/Inferno/InfernoScripts/InfernoCore/Isono/IsonoManager.cs
+++ b/Inferno/InfernoScripts/InfernoCore/Isono/IsonoManager.cs
@@ -39,8 +39,11 @@ namespace Inferno
             {
                 try
                 {
-                    _httpServer?.Stop();
-                    _httpServer?.Dispose();
+                    if(_httpServer is { IsDisposed: false })
+                    {
+                        _httpServer?.Stop();
+                        _httpServer?.Dispose();
+                    }
                 }
                 catch (Exception e)
                 {
@@ -49,7 +52,7 @@ namespace Inferno
 
                 if (x)
                 {
-                    _httpServer = new IsonoHttpServer(112);
+                    _httpServer = new IsonoHttpServer(_conf.Port);
                     _httpServer.OnReceivedMessageAsObservable
                         .ObserveOn(InfernoScheduler)
                         .Subscribe(c => InfernoCore.Publish(c));

--- a/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
+++ b/Inferno/InfernoScripts/Parupunte/ParupunteCore.cs
@@ -287,6 +287,7 @@ namespace Inferno.InfernoScripts.Parupunte
         /// </summary>
         private void ParupunteStart(Type script, CancellationToken ct)
         {
+            
             lock (_gate)
             {
                 if (IsActive)
@@ -307,8 +308,9 @@ namespace Inferno.InfernoScripts.Parupunte
                 _currentScript = Activator.CreateInstance(script, this, conf) as ParupunteScript;
                 ParupunteCoreLoopAsync(_currentScript, ct).Forget();
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                LogWrite(e);
                 IsActive = false;
             }
         }
@@ -425,6 +427,10 @@ namespace Inferno.InfernoScripts.Parupunte
                     IsActive = false;
                     _subTextUiContainer.Items.Clear();
                 }
+            }
+            catch (Exception e)
+            {
+                LogWrite(e.ToString());
             }
             finally
             {

--- a/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
@@ -4,7 +4,6 @@ using GTA;
 namespace Inferno.InfernoScripts.Parupunte.Scripts
 {
     [ParupunteIsono("けいさつ")]
-    [ParupunteDebug(true)]
     internal class ChangeWantedLevel : ParupunteScript
     {
         private readonly int wantedLevelThreshold = 1;

--- a/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
@@ -35,7 +35,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             else
             {
                 IncreasePlayerWantedLevel();
-                ReduceCounter = new ReduceCounter(30 * 1000);
+                ReduceCounter = new ReduceCounter(20 * 1000);
                 AddProgressBar(ReduceCounter);
                 ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
 

--- a/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
@@ -1,8 +1,10 @@
-﻿using GTA;
+﻿using System;
+using GTA;
 
 namespace Inferno.InfernoScripts.Parupunte.Scripts
 {
     [ParupunteIsono("けいさつ")]
+    [ParupunteDebug(true)]
     internal class ChangeWantedLevel : ParupunteScript
     {
         private readonly int wantedLevelThreshold = 1;
@@ -29,28 +31,28 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             if (wantedLevel >= wantedLevelThreshold)
             {
                 Game.Player.WantedLevel = 0;
+                ParupunteEnd();
             }
             else
             {
                 IncreasePlayerWantedLevel();
-            }
+                ReduceCounter = new ReduceCounter(30 * 1000);
+                AddProgressBar(ReduceCounter);
+                ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
 
-            ParupunteEnd();
+                OnFinishedAsObservable.Subscribe(_ =>
+                {
+                    Game.Player.WantedLevel = 0;
+                    core.DrawParupunteText("無罪放免", 1.0f);
+                });
+            }
         }
+
 
         private void IncreasePlayerWantedLevel()
         {
             var playerChar = Game.Player;
-            var MaxWantedLevel = Game.MaxWantedLevel;
-
-            if (MaxWantedLevel < playerChar.WantedLevel + 4)
-            {
-                playerChar.WantedLevel = MaxWantedLevel;
-            }
-            else
-            {
-                playerChar.WantedLevel = playerChar.WantedLevel + 4;
-            }
+            playerChar.WantedLevel = Game.MaxWantedLevel;
         }
     }
 }

--- a/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs
@@ -47,6 +47,14 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             }
         }
 
+        protected override void OnUpdate()
+        {
+            if (Game.Player.IsDead)
+            {
+                ParupunteEnd();
+            }
+        }
+
 
         private void IncreasePlayerWantedLevel()
         {

--- a/Inferno/InfernoScripts/Parupunte/Scripts/EveryoneFart.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/EveryoneFart.cs
@@ -118,8 +118,8 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                 {
                     if (ped.IsCutsceneOnlyPed())
                     {
-                        ped.Task.ClearAllImmediately();
-                        ped.SetToRagdoll(500);
+                        ped.Task.ClearAll();
+                        ped.SetToRagdoll(16);
                     }
                 }
 

--- a/Inferno/InfernoScripts/Parupunte/Scripts/EveryoneFart.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/EveryoneFart.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GTA;
+using GTA.Math;
+using GTA.Native;
+using Inferno.Utilities;
+
+namespace Inferno.InfernoScripts.Parupunte.Scripts
+{
+    [ParupunteIsono("みんなおなら")]
+    internal class EveryoneFart : ParupunteScript
+    {
+        public EveryoneFart(ParupunteCore core, ParupunteConfigElement element) : base(core, element)
+        {
+        }
+
+
+        public override void OnStart()
+        {
+            var ptfxName = "core";
+            if (!Function.Call<bool>(Hash.HAS_NAMED_PTFX_ASSET_LOADED, ptfxName))
+            {
+                Function.Call(Hash.REQUEST_NAMED_PTFX_ASSET, ptfxName);
+            }
+
+            FartAsync(ActiveCancellationToken).Forget();
+        }
+
+        private async ValueTask FartAsync(CancellationToken ct)
+        {
+            core.DrawParupunteText("みんなで 3", 1.0f);
+            await DelaySecondsAsync(1, ct);
+            core.DrawParupunteText("みんなで 2", 1.0f);
+            await DelaySecondsAsync(1, ct);
+            core.DrawParupunteText("みんなで 1", 1.0f);
+            await DelaySecondsAsync(1, ct);
+
+            core.DrawParupunteText("みんなで 発射！", 3.0f);
+
+            var player = core.PlayerPed;
+            var playerPos = player.Position;
+            var peds = core.CachedPeds.Where(x => x.IsSafeExist() && x.IsInRangeOf(playerPos, 30f))
+                .Concat(new[] { player })
+                .ToArray();
+
+            foreach (var ped in peds.Where(x => x.IsSafeExist()))
+            {
+                GasExplosion(ped);
+                CreateEffect(ped, "ent_sht_steam");
+
+                if (ped.IsInVehicle())
+                {
+                    ped.CurrentVehicle.SetForwardSpeed(300);
+                }
+
+                ped.SetToRagdoll(10);
+                ped.ApplyForce(Vector3.WorldUp * 30.0f);
+            }
+
+
+            ParupunteEnd();
+        }
+
+        private void GasExplosion(Ped shotPed)
+        {
+            var playerPos = shotPed.Position;
+            var targets = core.CachedPeds.Cast<Entity>()
+                .Concat(core.CachedVehicles)
+                .Where(x => x.IsSafeExist() && x.IsInRangeOf(shotPed.Position, 400));
+
+            Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+            {
+                playerPos.X,
+                playerPos.Y,
+                playerPos.Z,
+                -1,
+                0.5f,
+                true,
+                false,
+                0.5f
+            });
+
+            foreach (var e in targets)
+            {
+                if (e == shotPed) continue;
+                var dir = (e.Position - shotPed.Position).Normalized;
+                e.ApplyForce(dir * 1000.0f, Vector3.Zero, ForceType.MaxForceRot);
+            }
+        }
+
+        private void CreateEffect(Ped ped, string effect)
+        {
+            if (!ped.IsSafeExist())
+            {
+                return;
+            }
+
+            var offset = new Vector3(0.2f, 0.0f, 0.0f);
+            var rotation = new Vector3(80.0f, 10.0f, 0.0f);
+            var scale = 3.0f;
+            Function.Call(Hash.USE_PARTICLE_FX_ASSET, "core");
+            Function.Call<int>(Hash.START_PARTICLE_FX_NON_LOOPED_ON_PED_BONE, effect,
+                ped, offset.X, offset.Y, offset.Z, rotation.X, rotation.Y, rotation.Z, (int)Bone.SkelPelvis, scale, 0,
+                0, 0);
+        }
+    }
+}

--- a/Inferno/InfernoScripts/Parupunte/Scripts/EveryoneLikeYou.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/EveryoneLikeYou.cs
@@ -72,9 +72,17 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                     return;
                 }
 
-                var playerPos = core.PlayerPed.Position;
+                var playerPed = core.PlayerPed;
 
-                if (entity is Ped p)
+                if (entity is Vehicle v)
+                {
+                    if (playerPed.CurrentVehicle == v)
+                    {
+                        await DelaySecondsAsync(1, ct);
+                        continue;
+                    }
+                }
+                else if (entity is Ped p)
                 {
                     if (p.IsDead)
                     {
@@ -83,6 +91,8 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
                     p.SetToRagdoll();
                 }
+
+                var playerPos = playerPed.Position;
 
                 //プレイヤに向かうベクトル
                 var gotoPlayerVector = playerPos - entity.Position;

--- a/Inferno/InfernoScripts/Parupunte/Scripts/FishHeaven.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/FishHeaven.cs
@@ -53,11 +53,10 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             {
                 //周辺車両を監視
                 var playerPos = core.PlayerPed.Position;
-                foreach (var v in core.CachedVehicles.Where(
-                             x => x.IsSafeExist()
-                                  && !vehicles.Contains(x.Handle)
-                                  && x.IsAlive
-                                  && x.IsInRangeOf(playerPos, 50)
+                foreach (var v in core.CachedVehicles.Where(x => x.IsSafeExist()
+                                                                 && !vehicles.Contains(x.Handle)
+                                                                 && x.IsAlive
+                                                                 && x.IsInRangeOf(playerPos, 50)
                          ))
                 {
                     var driver = v.Driver;
@@ -166,7 +165,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
         /// <summary>
         /// 魚を生成する
         /// </summary>
-        private Ped SpawnFish(Vehicle target)
+        private Ped SpawnFish(Entity target)
         {
             var f = GTA.World.CreatePed(fishModel, target.Position + Vector3.WorldUp * 10);
             if (!f.IsSafeExist() || !target.IsSafeExist())

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
@@ -55,6 +55,15 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
             while (!ct.IsCancellationRequested && IsActive)
             {
+                // 画面が暗転してるか？
+                var fadedIn = Function.Call<bool>(Hash.IS_SCREEN_FADED_IN);
+                if (!fadedIn)
+                {
+                    // 画面が暗転している間は何もしない
+                    await DelaySecondsAsync(1, ct);
+                    continue;
+                }
+                
                 var isCutscene = Function.Call<bool>(Hash.IS_CUTSCENE_ACTIVE);
                 var playerPos = player.Position;
 
@@ -62,6 +71,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                 foreach (var ped in core.CachedPeds.Where(x =>
                              x.IsSafeExist() && x.IsInRangeOf(playerPos, pedRange) && x.IsAlive))
                 {
+                    if (ped.MayBeFriend()) continue;
 
                     ped.Task.ClearAllImmediately();
                     ped.SetToRagdoll(500);

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
@@ -1,4 +1,12 @@
 ﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GTA;
+using GTA.Math;
+using GTA.Native;
+using Inferno.Utilities;
 
 namespace Inferno.InfernoScripts.Parupunte.Scripts
 {
@@ -16,9 +24,11 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
         public override void OnStart()
         {
-            ReduceCounter = new ReduceCounter(15000);
+            ReduceCounter = new ReduceCounter(20000);
             ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
             AddProgressBar(ReduceCounter);
+            EffectAsync(ActiveCancellationToken).Forget();
+            AttackAsync(ActiveCancellationToken).Forget();
         }
 
         protected override void OnFinished()
@@ -37,6 +47,123 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             {
                 p.IsInvincible = true;
             }
+        }
+
+        private async ValueTask AttackAsync(CancellationToken ct)
+        {
+            var player = core.PlayerPed;
+
+            while (!ct.IsCancellationRequested && IsActive)
+            {
+                var playerPos = player.Position;
+
+                var pedRange = player.IsInVehicle() ? 6 : 4;
+                foreach (var ped in core.CachedPeds.Where(x =>
+                             x.IsSafeExist() && x.IsInRangeOf(playerPos, pedRange) && x.IsAlive))
+                {
+                    ped.SetToRagdoll(10);
+                    ped.Task.ClearAllImmediately();
+                    ped.Velocity = Vector3.WorldUp * 100f;
+
+                    Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+                    {
+                        ped.Position.X,
+                        ped.Position.Y,
+                        ped.Position.Z,
+                        GTA.ExplosionType.Rocket,
+                        0.0f,
+                        true,
+                        false,
+                        0.1f
+                    });
+
+                    await YieldAsync(ct);
+                }
+
+                var veRange = player.IsInVehicle() ? 10 : 8;
+
+                foreach (var ve in core.CachedVehicles.Where(x =>
+                             x.IsSafeExist() && x.IsInRangeOf(playerPos, veRange) && x != player.CurrentVehicle && x.IsAlive))
+                {
+                    ve.Velocity = Vector3.WorldUp * 100f;
+
+                    Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+                    {
+                        ve.Position.X,
+                        ve.Position.Y,
+                        ve.Position.Z,
+                        GTA.ExplosionType.Rocket,
+                        0.0f,
+                        true,
+                        false,
+                        0.1f
+                    });
+                    await YieldAsync(ct);
+
+                }
+
+                await YieldAsync(ct);
+            }
+        }
+
+
+        private async ValueTask EffectAsync(CancellationToken ct)
+        {
+            var player = core.PlayerPed;
+
+
+            var startTime = core.ElapsedTime;
+            while (!ct.IsCancellationRequested && IsActive)
+            {
+                var deltaTime = core.ElapsedTime - startTime;
+                var color = FromHsv(deltaTime * 360f / 0.5f, 1, 1);
+                NativeFunctions.CreateLight(
+                    player.Bones[Bone.SkelHead].Position + player.UpVector * 0.3f,
+                    color.R, color.G, color.B, 4, 150);
+
+                player.IsInvincible = true;
+
+                await YieldAsync(ct);
+            }
+        }
+
+        private static Color FromHsv(float h, float s, float v)
+        {
+            var hi = Convert.ToInt32(Math.Floor(h / 60)) % 6;
+            var f = h / 60 - (float)Math.Floor(h / 60);
+
+            v = v * 255;
+            var vInt = Convert.ToInt32(v);
+            var pInt = Convert.ToInt32(v * (1 - s));
+            var qInt = Convert.ToInt32(v * (1 - f * s));
+            var tInt = Convert.ToInt32(v * (1 - (1 - f) * s));
+
+            if (hi == 0)
+            {
+                return Color.FromArgb(255, vInt, tInt, pInt);
+            }
+
+            if (hi == 1)
+            {
+                return Color.FromArgb(255, qInt, vInt, pInt);
+            }
+
+            if (hi == 2)
+            {
+                return Color.FromArgb(255, pInt, vInt, tInt);
+            }
+
+            if (hi == 3)
+            {
+                return Color.FromArgb(255, pInt, qInt, vInt);
+            }
+
+            if (hi == 4)
+            {
+                return Color.FromArgb(255, tInt, pInt, vInt);
+            }
+
+            return Color.FromArgb(255, vInt, pInt, qInt);
         }
     }
 }

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
@@ -125,12 +125,11 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
         private async ValueTask EffectAsync(CancellationToken ct)
         {
-            var player = core.PlayerPed;
-
-
             var startTime = core.ElapsedTime;
             while (!ct.IsCancellationRequested && IsActive)
             {
+                var player = core.PlayerPed;
+
                 var deltaTime = core.ElapsedTime - startTime;
                 var color = FromHsv(deltaTime * 360f / 0.5f, 1, 1);
                 NativeFunctions.CreateLight(

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
@@ -24,7 +24,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
         public override void OnStart()
         {
-            ReduceCounter = new ReduceCounter(30000);
+            ReduceCounter = new ReduceCounter(20000);
             ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
             AddProgressBar(ReduceCounter);
             EffectAsync(ActiveCancellationToken).Forget();

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
@@ -24,7 +24,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
         public override void OnStart()
         {
-            ReduceCounter = new ReduceCounter(20000);
+            ReduceCounter = new ReduceCounter(30000);
             ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
             AddProgressBar(ReduceCounter);
             EffectAsync(ActiveCancellationToken).Forget();
@@ -55,51 +55,57 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
             while (!ct.IsCancellationRequested && IsActive)
             {
+                var isCutscene = Function.Call<bool>(Hash.IS_CUTSCENE_ACTIVE);
                 var playerPos = player.Position;
 
                 var pedRange = player.IsInVehicle() ? 6 : 4;
                 foreach (var ped in core.CachedPeds.Where(x =>
                              x.IsSafeExist() && x.IsInRangeOf(playerPos, pedRange) && x.IsAlive))
                 {
-                    ped.SetToRagdoll(10);
+
                     ped.Task.ClearAllImmediately();
-                    ped.Velocity = Vector3.WorldUp * 100f;
+                    ped.SetToRagdoll(500);
 
-                    Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+                    var speed = ped.IsCutsceneOnlyPed() ? 1f : 100f;
+                    ped.Velocity = Vector3.WorldUp * speed;
+                    if (!isCutscene)
                     {
-                        ped.Position.X,
-                        ped.Position.Y,
-                        ped.Position.Z,
-                        GTA.ExplosionType.Rocket,
-                        0.0f,
-                        true,
-                        false,
-                        0.1f
-                    });
-
-                    await YieldAsync(ct);
+                        Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+                        {
+                            ped.Position.X,
+                            ped.Position.Y,
+                            ped.Position.Z,
+                            GTA.ExplosionType.RayGun,
+                            0.0f,
+                            true,
+                            false,
+                            0.1f
+                        });
+                    }
                 }
 
                 var veRange = player.IsInVehicle() ? 10 : 8;
 
                 foreach (var ve in core.CachedVehicles.Where(x =>
-                             x.IsSafeExist() && x.IsInRangeOf(playerPos, veRange) && x != player.CurrentVehicle && x.IsAlive))
+                             x.IsSafeExist() && x.IsInRangeOf(playerPos, veRange) && x != player.CurrentVehicle &&
+                             x.IsAlive))
                 {
                     ve.Velocity = Vector3.WorldUp * 100f;
 
-                    Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+                    if (!isCutscene)
                     {
-                        ve.Position.X,
-                        ve.Position.Y,
-                        ve.Position.Z,
-                        GTA.ExplosionType.Rocket,
-                        0.0f,
-                        true,
-                        false,
-                        0.1f
-                    });
-                    await YieldAsync(ct);
-
+                        Function.Call(Hash.ADD_EXPLOSION, new InputArgument[]
+                        {
+                            ve.Position.X,
+                            ve.Position.Y,
+                            ve.Position.Z,
+                            GTA.ExplosionType.RayGun,
+                            0.0f,
+                            true,
+                            false,
+                            0.1f
+                        });
+                    }
                 }
 
                 await YieldAsync(ct);

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs
@@ -51,10 +51,10 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 
         private async ValueTask AttackAsync(CancellationToken ct)
         {
-            var player = core.PlayerPed;
-
             while (!ct.IsCancellationRequested && IsActive)
             {
+                var player = core.PlayerPed;
+
                 // 画面が暗転してるか？
                 var fadedIn = Function.Call<bool>(Hash.IS_SCREEN_FADED_IN);
                 if (!fadedIn)

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PositionShuffle.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PositionShuffle.cs
@@ -11,8 +11,6 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
 {
     [ParupunteConfigAttribute("あっちこっち", "おわり")]
     [ParupunteIsono("あっちこっち")]
-    // クラッシュするので封印
-    [ParupunteDebug(isIgnore: true)]
     internal class PositionShuffle : ParupunteScript
     {
         private readonly Random random = new();
@@ -40,7 +38,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                     SwapPedPositionAsync(p1, p2, ct).Forget();
                 }
 
-                await DelaySecondsAsync(1.5f, ct);
+                await DelaySecondsAsync(1f, ct);
             }
         }
 
@@ -78,7 +76,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             var isP2InVehicle = p2.IsInVehicle();
             var p2Pos = p2.Position;
             var v2 = p2.CurrentVehicle;
-            var v2seat = p1.SeatIndex;
+            var v2seat = p2.SeatIndex;
             var p2Requried = p2.IsRequiredForMission();
 
             #region P2を退避

--- a/Inferno/InfernoScripts/Parupunte/Scripts/PositionShuffle.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/PositionShuffle.cs
@@ -38,7 +38,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                     SwapPedPositionAsync(p1, p2, ct).Forget();
                 }
 
-                await DelaySecondsAsync(1f, ct);
+                await DelaySecondsAsync(2f, ct);
             }
         }
 

--- a/Inferno/InfernoScripts/Parupunte/Scripts/SpawnCharacters.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/SpawnCharacters.cs
@@ -27,7 +27,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
         {
             random = new Random();
 
-            switch (random.Next(0, 100) % 11)
+            switch (random.Next(0, 100) % 24)
             {
                 case 0:
                     pedModel = new Model(PedHash.LamarDavis);
@@ -83,6 +83,72 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                     pedModel = new Model(PedHash.Clown01SMY);
                     name = "らんらんる～";
                     break;
+                
+                case 11:
+                    pedModel = new Model(PedHash.Stretch);
+                    name = "やわらかストレッチ";
+                    break;
+                
+                case 12:
+                    pedModel = new Model(PedHash.DaveNorton);
+                    name = "ウツの会計士よ！";
+                    break;
+                
+                case 13:
+                    pedModel = new Model(PedHash.Denise);
+                    name = "女の威厳を取り戻せ！";
+                    break;
+                
+                case 14:
+                    pedModel = new Model(PedHash.KarenDaniels);
+                    name = "でーと を だいなしにした";
+                    break;
+                
+                case 15:
+                    pedModel = new Model(PedHash.MrK);
+                    name = "ミスターK";
+                    break;
+                
+                case 16:
+                    pedModel = new Model(PedHash.JimmyDisanto);
+                    name = "ジミーを怯えさせた";
+                    break;
+                
+                case 17:
+                    pedModel = new Model(PedHash.TracyDisanto);
+                    name = "パパの愛娘";
+                    break;
+                
+                case 18:
+                    pedModel = new Model(PedHash.TaoCheng);
+                    name = "來來來～";
+                    break;
+                
+                case 19:
+                    pedModel = new Model(PedHash.TaosTranslator);
+                    name = "メガネ";
+                    break;
+                
+                case 20:
+                    pedModel = new Model(PedHash.NervousRon);
+                    name = "やめロン";
+                    break;
+
+                case 21:
+                    pedModel = new Model(PedHash.AmandaTownley);
+                    name = "アマンダをビビらせた";
+                    break;
+                
+                case 22:
+                    pedModel = new Model(PedHash.Solomon);
+                    name = "憧れの男";
+                    break;
+                
+                case 23:
+                    pedModel = new Model(PedHash.Chop);
+                    name = "チョップ";
+                    break;
+                
             }
         }
 
@@ -101,7 +167,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
             // Vehicle seatをすべて列挙
             var seats = (VehicleSeat[])Enum.GetValues(typeof(VehicleSeat));
 
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < 50; i++)
             {
                 Ped ped = null;
 
@@ -121,7 +187,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                 }
                 else
                 {
-                    ped = GTA.World.CreatePed(pedModel, player.Position.AroundRandom2D(15));
+                    ped = GTA.World.CreatePed(pedModel, player.Position.AroundRandom2D(30) + player.Velocity);
                 }
                 
 
@@ -131,7 +197,7 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
                     GiveWeaponTpPed(ped);
                 }
 
-                await Delay100MsAsync(ct);
+                await YieldAsync(ct);
             }
 
             ParupunteEnd();

--- a/Inferno/InfernoScripts/Parupunte/Scripts/SpawnTaxies.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/SpawnTaxies.cs
@@ -35,18 +35,23 @@ namespace Inferno.InfernoScripts.Parupunte.Scripts
         private async ValueTask SpawnTaxi(CancellationToken ct)
         {
             var player = core.PlayerPed;
+            var driver = new Model(PedHash.LamarDavis);
 
-            for (int i = 0; i < 15; i++)
+            for (int i = 0; i < 20; i++)
             {
-                var pos = core.PlayerPed.Position.Around(5) + (Vector3.WorldUp * (float)Random.NextDouble() * 30.0f);
+                var pos = core.PlayerPed.Position.Around(15) + (Vector3.WorldUp * (float)Random.NextDouble() * 40.0f);
                 var taxi = GTA.World.CreateVehicle(VehicleHash.Taxi, pos,
                     (float)(Random.NextDouble() * 2f * Math.PI));
 
                 if (taxi.IsSafeExist())
                 {
                     taxi.MarkAsNoLongerNeeded();
-                    taxi.ApplyForce(-Vector3.WorldUp * 20.0f);
-                    var ped = taxi.CreateRandomPedAsDriver();
+                    taxi.ApplyForce(-Vector3.WorldUp * 0.0f);
+                    taxi.RotationVelocity = Vector3.RandomXYZ() * 10f;
+                    taxi.IsCollisionProof = true;
+                    taxi.IsMeleeProof = true;
+
+                    var ped = taxi.CreatePedOnSeat(VehicleSeat.Driver, driver);
                     if (ped.IsSafeExist())
                     {
                         ped.MarkAsNoLongerNeeded();

--- a/Inferno/InfernoScripts/Parupunte/Scripts/Transform.cs
+++ b/Inferno/InfernoScripts/Parupunte/Scripts/Transform.cs
@@ -1,31 +1,163 @@
-﻿using System;
-using System.Linq;
-using GTA;
-
-namespace Inferno.InfernoScripts.Parupunte.Scripts
-{
-    //[ParupunteConfigAttribute("変身GOGOベイビー")]
-    [ParupunteDebug(false, true)]
-    internal class Transform : ParupunteScript
-    {
-        public Transform(ParupunteCore core, ParupunteConfigElement element) : base(core, element)
-        {
-        }
-
-        public override void OnStart()
-        {
-            ReduceCounter = new ReduceCounter(30 * 1000);
-            AddProgressBar(ReduceCounter);
-            ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
-            var initialModel = core.PlayerPed.Model;
-
-            var hashed = Enum.GetValues(typeof(PedHash)).Cast<PedHash>().ToArray();
-            var targetHash = hashed[Random.Next(hashed.Length)];
-            var targetModel = new Model(targetHash);
-
-            Game.Player.ChangeModel(targetModel);
-            OnFinishedAsObservable
-                .Subscribe(_ => Game.Player.ChangeModel(initialModel));
-        }
-    }
-}
+﻿// using System;
+// using System.Linq;
+// using GTA;
+// using GTA.Native;
+//
+// namespace Inferno.InfernoScripts.Parupunte.Scripts
+// {
+//     [ParupunteConfigAttribute("変身GOGOベイビー")]
+//     [ParupunteDebug(true)]
+//     internal class Transform : ParupunteScript
+//     {
+//         public Transform(ParupunteCore core, ParupunteConfigElement element) : base(core, element)
+//         {
+//         }
+//
+//         public override void OnStart()
+//         {
+//             ReduceCounter = new ReduceCounter(30 * 1000);
+//             AddProgressBar(ReduceCounter);
+//             ReduceCounter.OnFinishedAsync.Subscribe(_ => ParupunteEnd());
+//             var initialModel = core.PlayerPed.Model;
+//
+//             var hashed = Enum.GetValues(typeof(PedHash)).Cast<PedHash>().ToArray();
+//             var targetHash = hashed[Random.Next(hashed.Length)];
+//             var targetModel = new Model(targetHash);
+//
+//             var old = OutfitHelper.SaveOutfit(core.PlayerPed);
+//
+//             Game.Player.ChangeModel(targetModel);
+//             OnFinishedAsObservable
+//                 .Subscribe(_ =>
+//                 {
+//                     Game.Player.ChangeModel(initialModel);
+//                     OutfitHelper.ApplyOutfit(core.PlayerPed, old);
+//                 });
+//         }
+//
+//
+//         public struct ComponentState
+//         {
+//             public int Drawable, Texture, Palette;
+//         }
+//
+//         public struct PropState
+//         {
+//             public int Index, Texture; // Index=-1 で未装備
+//         }
+//
+//         public class OutfitState
+//         {
+//             public ComponentState[] Components = new ComponentState[12];
+//             public PropState[] Props = new PropState[10];
+//         }
+//
+//         public static class OutfitHelper
+//         {
+//             public static OutfitState SaveOutfit(Ped ped)
+//             {
+//                 var o = new OutfitState();
+//                 // components
+//                 for (int c = 0; c <= 11; c++)
+//                 {
+//                     o.Components[c] = new ComponentState
+//                     {
+//                         Drawable = Function.Call<int>(Hash.GET_PED_DRAWABLE_VARIATION, ped.Handle, c),
+//                         Texture = Function.Call<int>(Hash.GET_PED_TEXTURE_VARIATION, ped.Handle, c),
+//                         Palette = Function.Call<int>(Hash.GET_PED_PALETTE_VARIATION, ped.Handle, c),
+//                     };
+//                 }
+//
+//                 // props（0..9のうち主に 0,1,2,6,7 を使う）
+//                 for (int p = 0; p <= 9; p++)
+//                 {
+//                     int idx = Function.Call<int>(Hash.GET_PED_PROP_INDEX, ped.Handle, p);
+//                     int tex = (idx >= 0)
+//                         ? Function.Call<int>(Hash.GET_PED_PROP_TEXTURE_INDEX, ped.Handle, p)
+//                         : 0;
+//
+//                     o.Props[p] = new PropState { Index = idx, Texture = tex };
+//                 }
+//
+//                 return o;
+//             }
+//
+//             public static float Clamp(float value, float min, float max)
+//             {
+//                 if (value < min)
+//                 {
+//                     return min;
+//                 }
+//
+//                 if (value > max)
+//                 {
+//                     return max;
+//                 }
+//
+//                 return value;
+//             }
+//
+//             public static int Clamp(int value, int min, int max)
+//             {
+//                 if (value < min)
+//                 {
+//                     return min;
+//                 }
+//
+//                 if (value > max)
+//                 {
+//                     return max;
+//                 }
+//
+//                 return value;
+//             }
+//
+//             public static void ApplyOutfit(Ped ped, OutfitState o)
+//             {
+//                 // 安全側：存在確認してから適用
+//                 for (int c = 0; c <= 11; c++)
+//                 {
+//                     var st = o.Components[c];
+//                     // drawable の存在確認
+//                     int dCount = Function.Call<int>(Hash.GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS, ped.Handle, c);
+//                     if (dCount <= 0) continue;
+//                     int drawable = Clamp(st.Drawable, 0, dCount - 1);
+//
+//                     // texture の存在確認
+//                     int tCount = Function.Call<int>(Hash.GET_NUMBER_OF_PED_TEXTURE_VARIATIONS, ped.Handle, c, drawable);
+//                     int texture = (tCount > 0) ? Clamp(st.Texture, 0, tCount - 1) : 0;
+//
+//                     // palette は 0..3 が多い（モデルにより異なる）ので 0–3 に丸め
+//                     int palette = Clamp(st.Palette, 0, 3);
+//
+//                     Function.Call(Hash.SET_PED_COMPONENT_VARIATION, ped.Handle, c, drawable, texture, palette);
+//                 }
+//
+//                 // props
+//                 for (int p = 0; p <= 9; p++)
+//                 {
+//                     var st = o.Props[p];
+//                     if (st.Index < 0)
+//                     {
+//                         Function.Call(Hash.CLEAR_PED_PROP, ped.Handle, p);
+//                         continue;
+//                     }
+//
+//                     int dCount = Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS, ped.Handle, p);
+//                     if (dCount <= 0)
+//                     {
+//                         Function.Call(Hash.CLEAR_PED_PROP, ped.Handle, p);
+//                         continue;
+//                     }
+//
+//                     int drawable = Clamp(st.Index, 0, dCount - 1);
+//                     int tCount = Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS, ped.Handle, p,
+//                         drawable);
+//                     int texture = (tCount > 0) ? Clamp(st.Texture, 0, tCount - 1) : 0;
+//
+//                     Function.Call(Hash.SET_PED_PROP_INDEX, ped.Handle, p, drawable, texture, true);
+//                 }
+//             }
+//         }
+//     }
+// }

--- a/Inferno/InfernoScripts/Players/BondCar.cs
+++ b/Inferno/InfernoScripts/Players/BondCar.cs
@@ -27,17 +27,17 @@ namespace Inferno.InfernoScripts.Player
                     IsActive = !IsActive;
                     DrawText("BondCar:" + IsActive);
                 });
-            
+
             IsActiveRP.Subscribe(x =>
             {
                 _invincibleMillSeconds = 0;
                 if (x)
                 {
-                    InvincibleVehicleAsync(ActivationCancellationToken).Forget();
                     InputLoopAsync(ActivationCancellationToken).Forget();
+                    InvincibleVehicleAsync(ActivationCancellationToken).Forget();
                 }
             });
-            
+
             CreateTickAsObservable(TimeSpan.FromSeconds(1))
                 .Where(_ => IsActive)
                 .Select(_ => PlayerPed.IsInVehicle())
@@ -73,14 +73,13 @@ namespace Inferno.InfernoScripts.Player
                 return;
             }
 
-            //そこら辺の市民のせいにする
-            var ped = CachedPeds.Where(x => x.IsSafeExist()).DefaultIfEmpty(PlayerPed).FirstOrDefault();
             _invincibleMillSeconds = 500;
-            CreateRpgBullet(v, ped, 1.5f);
-            CreateRpgBullet(v, ped, -1.5f);
+            v.IsExplosionProof = true;
+            CreateRpgBullet(v, 1.5f);
+            CreateRpgBullet(v, -1.5f);
         }
 
-        private void CreateRpgBullet(Vehicle vehicle, Ped ped, float rightOffset)
+        private void CreateRpgBullet(Vehicle vehicle, float rightOffset)
         {
             var startPosition = vehicle.GetOffsetFromEntityInWorldCoords(rightOffset, 0, 0.2f);
             var target = vehicle.GetOffsetFromEntityInWorldCoords(0, 1000, 0.2f);
@@ -107,26 +106,51 @@ namespace Inferno.InfernoScripts.Player
         {
             while (!ct.IsCancellationRequested && IsActive)
             {
-                var v = PlayerPed.CurrentVehicle;
+                // いま有効な“対象車両”を特定
+                var current = (PlayerPed.IsSafeExist() && PlayerPed.IsInVehicle())
+                    ? PlayerPed.CurrentVehicle
+                    : null;
+
+                if (!current.IsSafeExist())
+                {
+                    await DelaySecondsAsync(0.1f, ct);
+                    continue;
+                }
+
 
                 try
                 {
-                    if (v.IsSafeExist())
+                    // 同じ車に乗っている間だけ処理
+                    while (!ct.IsCancellationRequested && IsActive && current.IsSafeExist())
                     {
+                        // 乗り換え・降車検知
+                        var now = (PlayerPed.IsSafeExist() && PlayerPed.IsInVehicle())
+                            ? PlayerPed.CurrentVehicle
+                            : null;
+
+                        if (!now.IsSafeExist() || now != current)
+                        {
+                            break;
+                        }
+
                         if (_invincibleMillSeconds > 0)
                         {
-                            _invincibleMillSeconds -= 100;
-                            v.IsExplosionProof = !(_invincibleMillSeconds <= 0);
+                            _invincibleMillSeconds = Math.Max(0, _invincibleMillSeconds - 100);
+                            if (_invincibleMillSeconds <= 0)
+                            {
+                                current.IsExplosionProof = false;
+                            }
                         }
+                        
+                        await DelaySecondsAsync(0.1f, ct);
                     }
-
-                    await DelaySecondsAsync(0.1f, ct);
                 }
                 finally
                 {
-                    if (v.IsSafeExist())
+                    // 念のため対象車両は必ず解除
+                    if (current.IsSafeExist())
                     {
-                        v.IsExplosionProof = false;
+                        current.IsExplosionProof = false;
                     }
                 }
             }

--- a/Inferno/InfernoScripts/Players/BondCar.cs
+++ b/Inferno/InfernoScripts/Players/BondCar.cs
@@ -33,6 +33,9 @@ namespace Inferno.InfernoScripts.Player
                 _invincibleMillSeconds = 0;
                 if (x)
                 {
+                    // AssetLoad
+                    Function.Call(Hash.REQUEST_WEAPON_ASSET, Weapon.VEHICLE_ROCKET, 31, 0);
+                    
                     InputLoopAsync(ActivationCancellationToken).Forget();
                     InvincibleVehicleAsync(ActivationCancellationToken).Forget();
                 }
@@ -83,7 +86,6 @@ namespace Inferno.InfernoScripts.Player
         {
             var startPosition = vehicle.GetOffsetFromEntityInWorldCoords(rightOffset, 0, 0.2f);
             var target = vehicle.GetOffsetFromEntityInWorldCoords(0, 1000, 0.2f);
-
             Function.Call(
                 Hash.SHOOT_SINGLE_BULLET_BETWEEN_COORDS,
                 startPosition.X,
@@ -141,7 +143,7 @@ namespace Inferno.InfernoScripts.Player
                                 current.IsExplosionProof = false;
                             }
                         }
-                        
+
                         await DelaySecondsAsync(0.1f, ct);
                     }
                 }

--- a/Inferno/InfernoScripts/Players/EmergencyEscape.cs
+++ b/Inferno/InfernoScripts/Players/EmergencyEscape.cs
@@ -19,7 +19,7 @@ namespace Inferno
     public class EmergencyEscape : InfernoScript
     {
         private EmergencyEscapeConf conf;
-        private float EscapePower => conf?.Power ?? 60.0f;
+        private float EscapeVelocity => conf?.Velocity ?? 25.0f;
         protected override string ConfigFileName { get; } = "EmergencyEscape.conf";
 
         protected override void Setup()
@@ -74,12 +74,14 @@ namespace Inferno
                 player.CanRagdoll = true;
 
                 player.Task.LeaveVehicle(vec, LeaveVehicleFlags.WarpOut);
-                await YieldAsync(ct);
                 player.Position += new Vector3(0, 0, 1.0f);
+                await DelaySecondsAsync(0.1f, ct);
+
                 var shootPos = player.Position;
                 player.SetToRagdoll();
-                player.ApplyForce(new Vector3(0, 0, EscapePower) + vec.Velocity,
-                    Vector3.Zero, ForceType.MaxForceRot);
+                await YieldAsync(ct);
+                
+                player.Velocity = new Vector3(0, 0, EscapeVelocity) + vec.Velocity;
 
                 player.IsInvincible = true;
                 await DelayAsync(TimeSpan.FromSeconds(1.5f), ct);
@@ -104,12 +106,12 @@ namespace Inferno
         [Serializable]
         private class EmergencyEscapeConf : InfernoConfig
         {
-            private int _power = 60;
+            private int _velocity = 15;
 
-            public int Power
+            public int Velocity
             {
-                get => _power;
-                set => _power = value.Clamp(0, 100);
+                get => _velocity;
+                set => _velocity = value.Clamp(0, 100);
             }
 
             public override bool Validate()
@@ -133,18 +135,18 @@ namespace Inferno
         public override void OnUiMenuConstruct(ObjectPool pool, NativeMenu subMenu)
         {
             subMenu.AddSlider(
-                $"Ejection power: {conf.Power}",
+                $"Ejection velocity: {conf.Velocity}",
                 PlayerLocalize.EmergencyEscapePower,
-                conf.Power,
+                conf.Velocity,
                 100,
                 x =>
                 {
-                    x.Value = conf.Power;
-                    x.Multiplier = 5;
+                    x.Value = conf.Velocity;
+                    x.Multiplier = 1;
                 }, item =>
                 {
-                    conf.Power = item.Value;
-                    item.Title = $"Ejection power: {conf.Power}";
+                    conf.Velocity = item.Value;
+                    item.Title = $"Ejection velocity: {conf.Velocity}";
                 });
 
 

--- a/Inferno/InfernoScripts/Players/EmergencyEscape.cs
+++ b/Inferno/InfernoScripts/Players/EmergencyEscape.cs
@@ -123,6 +123,7 @@ namespace Inferno
                 await DelayAsync(TimeSpan.FromSeconds(1.0f), ct);
                 if (!ped.IsSafeExist()) return;
                 if (ped.IsInVehicle()) return;
+                if (!ped.IsInAir) return;
 
                 // 発射位置より高い位置にいる場合はパラシュートを開く
                 if (ped.Position.Z > shootPos.Z)

--- a/Inferno/InfernoScripts/Players/EmergencyEscape.cs
+++ b/Inferno/InfernoScripts/Players/EmergencyEscape.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using GTA;
 using GTA.Math;
 using GTA.Native;
+using Inferno.ChaosMode;
 using Inferno.InfernoScripts.InfernoCore.UI;
 using Inferno.Properties;
 using Inferno.Utilities;
@@ -94,6 +95,10 @@ namespace Inferno
                     isRequirePersitent = vec.IsPersistent;
                     vec.IsPersistent = true;
                 }
+                else
+                {
+                    ped.SetNotChaosPed(true);
+                }
 
                 ped.CanRagdoll = true;
 
@@ -135,6 +140,10 @@ namespace Inferno
                 if (ped == PlayerPed)
                 {
                     vec.IsPersistent = isRequirePersitent;
+                }
+                else
+                {
+                    ped.SetNotChaosPed(false);
                 }
             }
         }

--- a/Inferno/InfernoScripts/Players/EmergencyEscape.cs
+++ b/Inferno/InfernoScripts/Players/EmergencyEscape.cs
@@ -122,6 +122,7 @@ namespace Inferno
 
                 await DelayAsync(TimeSpan.FromSeconds(1.0f), ct);
                 if (!ped.IsSafeExist()) return;
+                if (ped.IsInVehicle()) return;
 
                 // 発射位置より高い位置にいる場合はパラシュートを開く
                 if (ped.Position.Z > shootPos.Z)

--- a/Inferno/InfernoScripts/Players/SpecialAbilityBgm.cs
+++ b/Inferno/InfernoScripts/Players/SpecialAbilityBgm.cs
@@ -6,8 +6,6 @@ using System.Reactive.Linq;
 using GTA;
 using Inferno.InfernoScripts.InfernoCore.UI;
 using Inferno.Properties;
-using LemonUI;
-using LemonUI.Menus;
 
 namespace Inferno
 {

--- a/Inferno/InfernoScripts/Worlds/ChaoticCutscene.cs
+++ b/Inferno/InfernoScripts/Worlds/ChaoticCutscene.cs
@@ -1,0 +1,300 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Inferno.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GTA;
+using GTA.Math;
+using Inferno.InfernoScripts.InfernoCore.UI;
+using Inferno.Properties;
+using LemonUI;
+using LemonUI.Menus;
+
+namespace Inferno
+{
+    public sealed class ChaoticCutscene : InfernoScript
+    {
+        [Serializable]
+        private class ChaoticCutsceneConfig : InfernoConfig
+        {
+            private int _frequency = 3;
+            private int _probability = 5;
+
+            public int Frequency
+            {
+                get => _frequency;
+                set => _frequency = value.Clamp(1, 30);
+            }
+
+            public int Probability
+            {
+                get => _probability;
+                set => _probability = value.Clamp(1, 100);
+            }
+
+            public override bool Validate()
+            {
+                if (_frequency <= 0) return false;
+                if (_probability < 1) return false;
+                if (_probability > 100) return false;
+                return true;
+            }
+        }
+
+
+        private readonly HashSet<Ped> _targets = new();
+        protected override string ConfigFileName { get; } = "ChaoticCutscene.conf";
+
+        private ChaoticCutsceneConfig _config;
+        
+        protected override bool DefaultAllOnEnable => false;
+
+        protected override void Setup()
+        {
+            _config ??= LoadConfig<ChaoticCutsceneConfig>();
+
+            CreateInputKeywordAsObservable("ChaoticCutscene", "cbreak")
+                .Subscribe(_ =>
+                {
+                    IsActive = !IsActive;
+                    DrawText($"CutScene Breaker:{IsActive}");
+                });
+
+            IsActiveRP
+                .Subscribe(x =>
+                {
+                    _targets.Clear();
+
+                    if (x)
+                    {
+                        LoopAsync(ActivationCancellationToken).Forget();
+                    }
+                });
+        }
+
+        private async ValueTask LoopAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                while (!Game.IsCutsceneActive)
+                {
+                    await DelaySecondsAsync(1, ct);
+                }
+
+                await CutSceneAsync(ct);
+            }
+        }
+
+        private async ValueTask CutSceneAsync(CancellationToken ct)
+        {
+            _targets.Clear();
+
+            while (Game.IsCutsceneActive && !ct.IsCancellationRequested)
+            {
+                var pedRange = 20;
+                var playerPos = PlayerPed.Position;
+
+                CutScenePedAsync(PlayerPed, ct).Forget();
+
+                foreach (var ped in CachedPeds.Where(x =>
+                             x.IsSafeExist() && x.IsRequiredForMission() && x.IsInRangeOf(playerPos, pedRange) &&
+                             x.IsAlive))
+                {
+                    CutScenePedAsync(ped, ct).Forget();
+                }
+
+                await DelaySecondsAsync(2, ct);
+            }
+        }
+
+        private async ValueTask CutScenePedAsync(Ped ped, CancellationToken ct)
+        {
+            if (!_targets.Add(ped)) return;
+
+            while (ped.IsSafeExist() && Game.IsCutsceneActive && !ct.IsCancellationRequested)
+            {
+                // 抽選
+                while (ped.IsSafeExist() && Game.IsCutsceneActive && !ct.IsCancellationRequested)
+                {
+                    if (Random.Next(0, 100) < _config.Probability)
+                    {
+                        break;
+                    }
+
+                    await DelaySecondsAsync(_config.Frequency, ct);
+                }
+
+
+                var randomSeconds = Random.Next(5, 10);
+                var shuffle = Random.Next(0, 7);
+                switch (shuffle)
+                {
+                    case 0:
+                        RagdollAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    case 1:
+                        RotationAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    case 2:
+                        SlideMoveAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    case 3:
+                        RagdollAsync(ped, randomSeconds, ct).Forget();
+                        RotationAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    case 4:
+                        RagdollAsync(ped, randomSeconds, ct).Forget();
+                        SlideMoveAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    case 5:
+                        RotationAsync(ped, randomSeconds, ct).Forget();
+                        SlideMoveAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    case 6:
+                        ShakeMoveAsync(ped, randomSeconds, ct).Forget();
+                        RagdollAsync(ped, randomSeconds, ct).Forget();
+                        break;
+
+                    default:
+                        RotationAsync(ped, randomSeconds, ct).Forget();
+                        SlideMoveAsync(ped, randomSeconds, ct).Forget();
+                        RagdollAsync(ped, randomSeconds, ct).Forget();
+                        break;
+                }
+
+                await DelaySecondsAsync(randomSeconds, ct);
+            }
+        }
+
+        // 脱力状態
+        private async ValueTask RagdollAsync(Ped ped, float seconds, CancellationToken ct)
+        {
+            var elapsedTime = 0f;
+            while (ped.IsSafeExist() && Game.IsCutsceneActive && !ct.IsCancellationRequested)
+            {
+                elapsedTime += DeltaTime;
+                if (elapsedTime >= seconds) return;
+
+                ped.Task.ClearAllImmediately();
+                ped.SetToRagdoll(500);
+
+                await YieldAsync(ct);
+            }
+        }
+
+        private async ValueTask RotationAsync(Ped ped, float seconds, CancellationToken ct)
+        {
+            var elapsedTime = 0f;
+
+            var randomXYZ = Vector3.RandomXYZ();
+            var power = (float)Random.NextDouble() * 50f;
+
+            while (ped.IsSafeExist() && Game.IsCutsceneActive && !ct.IsCancellationRequested)
+            {
+                elapsedTime += DeltaTime;
+                if (elapsedTime >= seconds) return;
+
+                ped.RotationVelocity = (power * randomXYZ);
+                await YieldAsync(ct);
+            }
+        }
+
+        private async ValueTask SlideMoveAsync(Ped ped, float seconds, CancellationToken ct)
+        {
+            var elapsedTime = 0f;
+
+            var randomXYZ = Vector3.RandomXYZ();
+            var power = (float)Random.NextDouble();
+
+            while (ped.IsSafeExist() && Game.IsCutsceneActive && !ct.IsCancellationRequested)
+            {
+                elapsedTime += DeltaTime;
+                if (elapsedTime >= seconds) return;
+
+                ped.Velocity = (power * randomXYZ);
+                await YieldAsync(ct);
+            }
+        }
+
+        private async ValueTask ShakeMoveAsync(Ped ped, float seconds, CancellationToken ct)
+        {
+            var elapsedTime = 0f;
+
+            while (ped.IsSafeExist() && Game.IsCutsceneActive && !ct.IsCancellationRequested)
+            {
+                elapsedTime += DeltaTime;
+                if (elapsedTime >= seconds) return;
+                var randomXYZ = Vector3.RandomXYZ();
+                var power = (float)Random.NextDouble() * 5f;
+                ped.Velocity = (power * randomXYZ);
+                await YieldAsync(ct);
+            }
+        }
+
+        public override bool UseUI => true;
+        public override string DisplayName => MiscLocalization.CutSceneTitle;
+
+        public override string Description => MiscLocalization.CutSceneDescription;
+
+        public override bool CanChangeActive => true;
+
+        public override MenuIndex MenuIndex => MenuIndex.Misc;
+        
+
+        public override void OnUiMenuConstruct(ObjectPool pool, NativeMenu subMenu)
+        {
+            _config ??= LoadConfig<ChaoticCutsceneConfig>();
+
+
+            subMenu.AddSlider(
+                $"Frequency: {_config.Frequency}[s]",
+                MiscLocalization.CutSceneFrequecy,
+                _config.Frequency,
+                30,
+                x =>
+                {
+                    x.Value = _config.Frequency;
+                    x.Multiplier = 1;
+                }, item =>
+                {
+                    _config.Frequency = item.Value;
+                    item.Title = $"Frequency: {_config.Frequency}[s]";
+                });
+
+            subMenu.AddSlider(
+                $"Probability: {_config.Probability}[%]",
+                MiscLocalization.CutSceneProbabillity,
+                _config.Probability,
+                100,
+                x =>
+                {
+                    x.Value = _config.Probability;
+                    x.Multiplier = 1;
+                }, item =>
+                {
+                    _config.Probability = item.Value;
+                    item.Title = $"Probability: {_config.Probability}[%]";
+                });
+
+            subMenu.AddButton(InfernoCommon.DefaultValue, "", _ =>
+            {
+                _config = LoadDefaultConfig<ChaoticCutsceneConfig>();
+                subMenu.Visible = false;
+                subMenu.Visible = true;
+            });
+
+            subMenu.AddButton(InfernoCommon.SaveConf, InfernoCommon.SaveConfDescription, _ =>
+            {
+                SaveConfig(_config);
+                DrawText($"Saved to {ConfigFileName}");
+            });
+        }
+    }
+}

--- a/Inferno/InfernoScripts/Worlds/Meteor.cs
+++ b/Inferno/InfernoScripts/Worlds/Meteor.cs
@@ -26,7 +26,7 @@ namespace Inferno
         protected override void Setup()
         {
             _config = LoadConfig<MeteorConfig>();
-            CreateInputKeywordAsObservable("Meteor","meteo")
+            CreateInputKeywordAsObservable("Meteor", "meteo")
                 .Subscribe(_ =>
                 {
                     IsActive = !IsActive;
@@ -42,8 +42,6 @@ namespace Inferno
                     MeteorLoopAsync(ActivationCancellationToken).Forget();
                     DebugLoopAsync(ActivationCancellationToken).Forget();
                 });
-
-           
         }
 
         private async ValueTask MeteorLoopAsync(CancellationToken ct)
@@ -195,7 +193,7 @@ namespace Inferno
 
                 var lenght = (PlayerPed.Position - position).Length();
                 // マーカー描画範囲内
-                if (lenght <= markerThreshold)
+                if (lenght <= markerThreshold && ShowCountDown)
                 {
                     var alpha = 150 * ((markerThreshold - lenght) / markerThreshold).Clamp(0, 1f);
 
@@ -209,7 +207,7 @@ namespace Inferno
                         false, true, 2, null, null, false);
                 }
 
-                NativeFunctions.CreateLight(position + Vector3.WorldUp, 255, 50, 50, 3f, 500f);
+                NativeFunctions.CreateLight(position + Vector3.WorldUp, 255, 10, 10, 3f, 400f);
 
 
                 await YieldAsync(ct);
@@ -279,6 +277,13 @@ namespace Inferno
                     _config.Probability = item.Value;
                 });
 
+            subMenu.AddCheckbox(
+                "Show CountDown",
+                MeteorLocalize.CountDown,
+              x=>x.Checked=  _config.ShowCountDown,
+                x => _config.ShowCountDown = x);
+            
+            
             // Debug
             {
                 var debugItem = new NativeCheckboxItem("Debug", _isDebug);
@@ -286,14 +291,14 @@ namespace Inferno
                 subMenu.Add(debugItem);
             }
 
-            subMenu.AddButton(InfernoCommon.DefaultValue,"", _ =>
+            subMenu.AddButton(InfernoCommon.DefaultValue, "", _ =>
             {
                 _config = LoadDefaultConfig<MeteorConfig>();
                 subMenu.Visible = false;
                 subMenu.Visible = true;
             });
 
-            subMenu.AddButton(InfernoCommon.SaveConf,  InfernoCommon.SaveConfDescription, _ =>
+            subMenu.AddButton(InfernoCommon.SaveConf, InfernoCommon.SaveConfDescription, _ =>
             {
                 SaveConfig(_config);
                 DrawText($"Saved to {ConfigFileName}");
@@ -336,6 +341,14 @@ namespace Inferno
                 set => _probability = value.Clamp(0, 100);
             }
 
+            [JsonProperty("ShowCountDown")]
+            public bool ShowCountDown
+            {
+                get => _showCountDown;
+                set => _showCountDown = value;
+            }
+
+            private bool _showCountDown = true;
             private int _radius = 30;
             private int _durationMillSeconds = 1000;
             private int _probability = 40;
@@ -348,7 +361,7 @@ namespace Inferno
             public override string ToString()
             {
                 return
-                    $"{nameof(Radius)}: {Radius}, {nameof(DurationMillSeconds)}: {DurationMillSeconds}, {nameof(Probability)}: {Probability}";
+                    $"{nameof(Radius)}: {Radius}, {nameof(DurationMillSeconds)}: {DurationMillSeconds}, {nameof(Probability)}: {Probability}, {nameof(ShowCountDown)}: {ShowCountDown}";
             }
         }
 
@@ -357,6 +370,8 @@ namespace Inferno
         private float Radius => _config?.Radius ?? 30;
         private float DurationMillSeconds => _config?.DurationMillSeconds ?? 1000;
         private int Probability => _config?.Probability ?? 25;
+        
+        private bool ShowCountDown => _config?.ShowCountDown ?? true;
 
         #endregion
     }

--- a/Inferno/InfernoScripts/Worlds/Meteor.cs
+++ b/Inferno/InfernoScripts/Worlds/Meteor.cs
@@ -37,8 +37,7 @@ namespace Inferno
                 .Where(x => x)
                 .Subscribe(_ =>
                 {
-                    var m = new Model(WeaponHash.RPG);
-                    m.Request();
+                    Function.Call(Hash.REQUEST_WEAPON_ASSET, WeaponHash.RPG, 31, 0);
                     MeteorLoopAsync(ActivationCancellationToken).Forget();
                     DebugLoopAsync(ActivationCancellationToken).Forget();
                 });

--- a/Inferno/InfernoScripts/Worlds/SpeedMax.cs
+++ b/Inferno/InfernoScripts/Worlds/SpeedMax.cs
@@ -47,6 +47,8 @@ namespace Inferno.InfernoScripts.World
                                      x.IsSafeExist()
                                      && x.IsInRangeOf(PlayerPed.Position, 100.0f)
                                      && !_vehicleHashSet.Contains(x.Handle)
+                                     && x.GetPedOnSeat(VehicleSeat.Driver).IsSafeExist()
+                                     && !x.IsPlayerVehicle()
                                      && !(_excludeMissionVehicle && x.IsPersistent)
                                  ))
                     {

--- a/Inferno/Properties/EntitiesLocalize.Designer.cs
+++ b/Inferno/Properties/EntitiesLocalize.Designer.cs
@@ -168,6 +168,51 @@ namespace Inferno.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Execute immediately.
+        /// </summary>
+        internal static string ForceRideAction {
+            get {
+                return ResourceManager.GetString("ForceRideAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When a player repeatedly sounds the horn while driving, nearby citizens are forced to get into your car..
+        /// </summary>
+        internal static string ForceRideDescription {
+            get {
+                return ResourceManager.GetString("ForceRideDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required number of hits..
+        /// </summary>
+        internal static string ForceRideInputCount {
+            get {
+                return ResourceManager.GetString("ForceRideInputCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Input grace period for repeated honking..
+        /// </summary>
+        internal static string ForceRideInputTimeout {
+            get {
+                return ResourceManager.GetString("ForceRideInputTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Forced entry.
+        /// </summary>
+        internal static string ForceRideTitle {
+            get {
+                return ResourceManager.GetString("ForceRideTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Citizens paratroop down near the player..
         /// </summary>
         internal static string ParachuteDescription {

--- a/Inferno/Properties/EntitiesLocalize.ja.resx
+++ b/Inferno/Properties/EntitiesLocalize.ja.resx
@@ -71,4 +71,19 @@
     <data name="ParachuteIntterval" xml:space="preserve">
         <value>市民の生成間隔。</value>
     </data>
+    <data name="ForceRideTitle" xml:space="preserve">
+        <value>強制乗車</value>
+    </data>
+    <data name="ForceRideDescription" xml:space="preserve">
+        <value>乗車中にクラクションを連打することで周辺市民を強制的に自分の車に乗せます。</value>
+    </data>
+    <data name="ForceRideInputTimeout" xml:space="preserve">
+        <value>クラクション連打の入力猶予時間。</value>
+    </data>
+    <data name="ForceRideInputCount" xml:space="preserve">
+        <value>必要連打数。</value>
+    </data>
+    <data name="ForceRideAction" xml:space="preserve">
+        <value>今すぐ実行</value>
+    </data>
 </root>

--- a/Inferno/Properties/EntitiesLocalize.resx
+++ b/Inferno/Properties/EntitiesLocalize.resx
@@ -78,4 +78,19 @@
     <data name="ParachuteIntterval" xml:space="preserve">
         <value>Citizen generation interval.</value>
     </data>
+    <data name="ForceRideTitle" xml:space="preserve">
+        <value>Forced entry</value>
+    </data>
+    <data name="ForceRideDescription" xml:space="preserve">
+        <value>When a player repeatedly sounds the horn while driving, nearby citizens are forced to get into your car.</value>
+    </data>
+    <data name="ForceRideInputTimeout" xml:space="preserve">
+        <value>Input grace period for repeated honking.</value>
+    </data>
+    <data name="ForceRideInputCount" xml:space="preserve">
+        <value>Required number of hits.</value>
+    </data>
+    <data name="ForceRideAction" xml:space="preserve">
+        <value>Execute immediately</value>
+    </data>
 </root>

--- a/Inferno/Properties/MeteorLocalize.Designer.cs
+++ b/Inferno/Properties/MeteorLocalize.Designer.cs
@@ -60,6 +60,15 @@ namespace Inferno.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show countdown on marker..
+        /// </summary>
+        internal static string CountDown {
+            get {
+                return ResourceManager.GetString("CountDown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to RPG bullets will rain down from the sky around the player..
         /// </summary>
         internal static string Description {

--- a/Inferno/Properties/MeteorLocalize.ja.resx
+++ b/Inferno/Properties/MeteorLocalize.ja.resx
@@ -26,4 +26,7 @@
     <data name="Probability" xml:space="preserve">
         <value>メテオの落下確率。</value>
     </data>
+    <data name="CountDown" xml:space="preserve">
+        <value>マーカーにカウントダウンを表示する。</value>
+    </data>
 </root>

--- a/Inferno/Properties/MeteorLocalize.resx
+++ b/Inferno/Properties/MeteorLocalize.resx
@@ -33,4 +33,7 @@
     <data name="Probability" xml:space="preserve">
         <value>Meteor fall probability.</value>
     </data>
+    <data name="CountDown" xml:space="preserve">
+        <value>Show countdown on marker.</value>
+    </data>
 </root>

--- a/Inferno/Properties/MiscLocalization.Designer.cs
+++ b/Inferno/Properties/MiscLocalization.Designer.cs
@@ -60,6 +60,43 @@ namespace Inferno.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Characters movements become chaotic during cutscenes.
+        ///Warning: Some cutscenes may cause the game to crash..
+        /// </summary>
+        internal static string CutSceneDescription {
+            get {
+                return ResourceManager.GetString("CutSceneDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Chaotic frequency [s].
+        /// </summary>
+        internal static string CutSceneFrequecy {
+            get {
+                return ResourceManager.GetString("CutSceneFrequecy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Probability of Chaos [%].
+        /// </summary>
+        internal static string CutSceneProbabillity {
+            get {
+                return ResourceManager.GetString("CutSceneProbabillity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ChaoticCutscene.
+        /// </summary>
+        internal static string CutSceneTitle {
+            get {
+                return ResourceManager.GetString("CutSceneTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Displays cause of death upon player death..
         /// </summary>
         internal static string DisplayCoDDescription {

--- a/Inferno/Properties/MiscLocalization.ja.resx
+++ b/Inferno/Properties/MiscLocalization.ja.resx
@@ -17,4 +17,17 @@
     <data name="DisplayCoDDescription" xml:space="preserve">
         <value>プレイヤー死亡時に死因を表示します。</value>
     </data>
+    <data name="CutSceneTitle" xml:space="preserve">
+        <value>カオスカットシーン</value>
+    </data>
+    <data name="CutSceneDescription" xml:space="preserve">
+        <value>カットシーン中のキャラクターの動きをめちゃくちゃにします。
+※カットシーンによってはクラッシュすることがあります。</value>
+    </data>
+    <data name="CutSceneProbabillity" xml:space="preserve">
+        <value>キャラクター1人あたりのカオスになる確率。</value>
+    </data>
+    <data name="CutSceneFrequecy" xml:space="preserve">
+        <value>キャラクター1人あたりのカオスになる頻度。</value>
+    </data>
 </root>

--- a/Inferno/Properties/MiscLocalization.resx
+++ b/Inferno/Properties/MiscLocalization.resx
@@ -24,4 +24,17 @@
     <data name="DisplayCoDDescription" xml:space="preserve">
         <value>Displays cause of death upon player death.</value>
     </data>
+    <data name="CutSceneTitle" xml:space="preserve">
+        <value>ChaoticCutscene</value>
+    </data>
+    <data name="CutSceneDescription" xml:space="preserve">
+        <value>Characters movements become chaotic during cutscenes.
+Warning: Some cutscenes may cause the game to crash.</value>
+    </data>
+    <data name="CutSceneFrequecy" xml:space="preserve">
+        <value>Chaotic frequency [s]</value>
+    </data>
+    <data name="CutSceneProbabillity" xml:space="preserve">
+        <value>Probability of Chaos [%]</value>
+    </data>
 </root>

--- a/Inferno/Properties/PlayerLocalize.Designer.cs
+++ b/Inferno/Properties/PlayerLocalize.Designer.cs
@@ -171,7 +171,7 @@ namespace Inferno.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ejection power..
+        ///   Looks up a localized string similar to Ejection velocitty..
         /// </summary>
         internal static string EmergencyEscapePower {
             get {

--- a/Inferno/Properties/PlayerLocalize.Designer.cs
+++ b/Inferno/Properties/PlayerLocalize.Designer.cs
@@ -171,7 +171,7 @@ namespace Inferno.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ejection velocitty..
+        ///   Looks up a localized string similar to Ejection velocity..
         /// </summary>
         internal static string EmergencyEscapePower {
             get {

--- a/Inferno/Properties/PlayerLocalize.ja.resx
+++ b/Inferno/Properties/PlayerLocalize.ja.resx
@@ -91,7 +91,7 @@
         <value>クラクションを鳴らしながら車から降りようとすると緊急脱出します。</value>
     </data>
     <data name="EmergencyEscapePower" xml:space="preserve">
-        <value>射出力。</value>
+        <value>発射速度。</value>
     </data>
     <data name="FloatingTitle" xml:space="preserve">
         <value>ふわふわジャンプ</value>

--- a/Inferno/Properties/PlayerLocalize.resx
+++ b/Inferno/Properties/PlayerLocalize.resx
@@ -99,7 +99,7 @@ Yellow: Time remaining before explosion</value>
         <value>Getting out of the car while honking the horn activates the emergency ejection.</value>
     </data>
     <data name="EmergencyEscapePower" xml:space="preserve">
-        <value>Ejection velocitty.</value>
+        <value>Ejection velocity.</value>
     </data>
     <data name="FloatingDescription" xml:space="preserve">
         <value>Holding down jump and sprint at the same time causes the player to fluff up and jump up.</value>

--- a/Inferno/Properties/PlayerLocalize.resx
+++ b/Inferno/Properties/PlayerLocalize.resx
@@ -99,7 +99,7 @@ Yellow: Time remaining before explosion</value>
         <value>Getting out of the car while honking the horn activates the emergency ejection.</value>
     </data>
     <data name="EmergencyEscapePower" xml:space="preserve">
-        <value>Ejection power.</value>
+        <value>Ejection velocitty.</value>
     </data>
     <data name="FloatingDescription" xml:space="preserve">
         <value>Holding down jump and sprint at the same time causes the player to fluff up and jump up.</value>

--- a/Inferno/Utilities/Http/SimpleJsonHttpServer.cs
+++ b/Inferno/Utilities/Http/SimpleJsonHttpServer.cs
@@ -29,7 +29,7 @@ namespace Inferno.Utilities.Http
             _cts?.Dispose();
             _cts = new CancellationTokenSource();
 
-            _httpListener.Start();
+            Task.Run(() => _httpListener.Start());
             _ = HandleRequestsAsync(_cts.Token);
         }
 

--- a/Inferno/Utilities/InfernoUtilities.cs
+++ b/Inferno/Utilities/InfernoUtilities.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Disposables;
+using System.Threading;
 using System.Threading.Tasks;
 using GTA.Math;
 


### PR DESCRIPTION

## 追加されたクラス/機能
- `Inferno/InfernoScripts/Citizen/CitizenForceRide.cs`
  - クラクション連打で周辺の市民をプレイヤー車に強制乗車。
  - 入力猶予（`Period`）/必要連打数（`Hit`）の設定、UI（即時実行ボタン/スライダー）。
  - ミッション対象者の優先、処理中 Ped の重複抑止、Reactive による入力バッファリング。
- `Inferno/InfernoScripts/Parupunte/Scripts/EveryoneFart.cs`
  - 周辺 Ped＋プレイヤーにガス噴射エフェクトと爆風、ラグドール化・垂直加速・車両降車（プレイヤーは車両加速）。
- `Inferno/InfernoScripts/Worlds/ChaoticCutscene.cs`
  - カットシーン中、近傍 Ped を一定頻度/確率で「回転」「滑走」「揺れ」「ラグドール」させる。
  - `Frequency`/`Probability` 設定と UI、対象のインビンシブル制御・復元、負荷/再入性に配慮。
- `Inferno/Inferno.csproj`
  - 上記 3 クラスをコンパイル対象に追加。

## 変更（ゲームロジック）
- `Inferno/ChaosMode/ChaosMode.cs`
  - 対象 Ped を人間のみに限定（`IsHuman` 追加）。
- `Inferno/ExtensionMethods/ExtensionMethods.cs`
  - `Ped.MayBeFriend()` を追加（同乗・グループ・関係値・ブリップ・追従タスクから味方推定）。
  - `IEnumerable<T>.Around(target, range)` を追加（範囲フィルタ）。

### Citizen 系
- `Inferno/InfernoScripts/Citizen/CitizenNitro.cs`
  - 対象車両に `IsAlive` 条件を追加。
- `Inferno/InfernoScripts/Citizen/CitizenRobberVehicle.cs`
  - 対象選定に `IsHuman` を追加、軽微な整理。

### Player 系
- `Inferno/InfernoScripts/Players/BondCar.cs`
  - ロケット Asset の事前ロード、発射処理の安定化（同一車両滞在中のみ爆発無効維持、乗換時は確実解除）。
  - 罪被せ用 Ped 引数の削除、爆発無効のカウントダウン制御を堅牢化。
- `Inferno/InfernoScripts/Players/EmergencyEscape.cs`
  - 射出「力」→「速度」へ指標変更（`Power`→`Velocity`）。
  - プレイヤー以外の同乗者にもパラシュート脱出適用、当たり判定/インビンシブル/位置調整/コリジョン再有効化を追加。
  - 車両 `IsPersistent` の一時変更と復元、UI とローカライズ更新。
- `Inferno/InfernoScripts/Players/Warp.cs`
  - ワープを非同期化、事前コリジョン要求、`PositionNoOffset` での埋まり防止、UI ハンドラも非同期化。
- `Inferno/InfernoScripts/Players/SpecialAbilityBgm.cs`
  - 未使用 using の削除（整理）。

### Worlds 系
- `Inferno/InfernoScripts/Worlds/Meteor.cs`
  - RPG アセット要求をネイティブ呼び出しへ、ライト色/距離調整。
  - UI に「CountDown 表示」追加、描画も設定に追従、文字列整形修正。
- `Inferno/InfernoScripts/Worlds/SpeedMax.cs`
  - 対象車両を「ドライバーあり」「プレイヤー車両以外」に限定。

### Parupunte 系
- `Inferno/InfernoScripts/Parupunte/Scripts/BeastFriends.cs`
  - 召喚ロジックを全面刷新。周辺に大量スポーン（100 体ループ）、非人間への `NotChaos` 設定、無敵化、プレイヤーに敵対行動、非同期化。
- `Inferno/InfernoScripts/Parupunte/Scripts/ChangeWantedLevel.cs`
  - 閾値以上は即 0、未満は最大まで引き上げ＋20 秒カウント後に 0。死亡で終了。UI/表示追加。
- `Inferno/InfernoScripts/Parupunte/Scripts/EveryoneLikeYou.cs`
  - プレイヤー乗車中の車両をターゲットから除外、死亡チェック順序など整理。
- `Inferno/InfernoScripts/Parupunte/Scripts/FishHeaven.cs`
  - `SpawnFish` の引数を `Vehicle`→`Entity` に拡張、クエリ整形（機能同等）。
- `Inferno/InfernoScripts/Parupunte/Scripts/Isono.cs`
  - `CollisionProof`→`IsInvincible` 中心へ移行、車両も同様に統一。
  - 空中判定の安定化（速度閾値併用）、空中での引き寄せ・着地後の一斉吹き飛ばし＋爆発、Persistent 復元を堅牢化。
- `Inferno/InfernoScripts/Parupunte/Scripts/PlayerInvincible.cs`
  - 効果 15→20 秒。周辺 Ped/Vehicle をラグドール/上方加速させる攻撃オーラ追加、虹色ライト演出。
  - カットシーン時は演出のみ、`MayBeFriend()` で味方っぽい Ped を除外。
- `Inferno/InfernoScripts/Parupunte/Scripts/PositionShuffle.cs`
  - 旧デバッグ封印を解除、遅延調整、座席インデックスのバグ修正（`v2seat = p2.SeatIndex`）。
- `Inferno/InfernoScripts/Parupunte/Scripts/SpawnCharacters.cs`
  - 出現候補 11→24 に増加（有名 NPC/チョップ等）。
  - 近傍車両の座席に配置する処理を分離、徒歩スポーンは別途、耐性（Proof）付与ヘルパ追加。即戦闘指示は削除。
- `Inferno/InfernoScripts/Parupunte/Scripts/SpawnTaxies.cs`
  - スポーン数・高度/距離・回転・耐性調整。運転手を Lamar 固定で `CreatePedOnSeat`。
- `Inferno/InfernoScripts/Parupunte/Scripts/Transform.cs`
  - 既存実装をコメントアウトし、衣装セーブ/適用を含む拡張案を併記（現状は無効、将来実装用）。

## コア/ユーティリティ
- `Inferno/InfernoScripts/InfernoCore/InfernoScript.cs`
  - 例外ログに `StackTrace` を含めて可観測性向上。
- `Inferno/InfernoScripts/InfernoCore/Isono/IsonoHttpServer.cs`
  - `IsDisposed` 追加、`Dispose()` 時にフラグ設定。
- `Inferno/InfernoScripts/InfernoCore/Isono/IsonoManager.cs`
  - HTTP サーバ停止/Dispose の二重実行防止。ポートを固定 `112`→設定値（`_conf.Port`）。
- `Inferno/Utilities/Http/SimpleJsonHttpServer.cs`
  - `HttpListener.Start()` を別スレッド起動してブロッキング回避。
- `Inferno/Utilities/InfernoUtilities.cs`
  - `using System.Threading;` を追加。

## リソース/ローカライズ
- `EntitiesLocalize.*`
  - ForceRide 用のタイトル/説明/入力猶予/必要連打数/実行ボタン文言を追加。
- `MeteorLocalize.*`
  - 「カウントダウン表示（CountDown）」項目を追加。
- `MiscLocalization.*`
  - ChaoticCutscene のタイトル/説明/頻度/確率の文言を追加。
- `PlayerLocalize.*`
  - EmergencyEscape の文言を「射出力」→「発射速度」に変更。
